### PR TITLE
Run cages from python SDK and fix crypto client to only load cage key once per lifecycle of evervault client instance

### DIFF
--- a/evervault/client.py
+++ b/evervault/client.py
@@ -7,33 +7,35 @@ class Client(object):
         self,
         api_key="your_teams_api_key",
         request_timeout=30,
-        base_url="https://api.evervault.com",
-        base_run_url="https://cage.run",
+        base_url="https://api.evervault.com/",
+        base_run_url="https://cage.run/",
     ):
         self.api_key = api_key
         self.base_url = base_url
         self.base_run_url = base_run_url
         self.request = Request(api_key, request_timeout)
+        self.crypto_client = CryptoClient()
 
     @property
     def _auth(self):
         return (self.api_key, "")
 
     def encrypt(self, data):
-        client = CryptoClient()
-        return client.encrypt_data(self, data)
+        return self.crypto_client.encrypt_data(self, data)
 
-    def run(self, cage_name, params):
-        pass
+    def run(self, cage_name, encrypted_data, cage_run = True):
+        path = cage_name if cage_run else f'cages/{cage_name}'
+        return self.post(path, encrypted_data, cage_run)
 
-    def encrypt_and_run(self, cage_name, params):
-        pass
+    def encrypt_and_run(self, cage_name, data, cage_run = True):
+        encrypted_data = self.encrypt(data)
+        return self.run(cage_name, encrypted_data, cage_run)
 
     def get(self, path, params={}):
         return self.request.make_request("GET", self.url(path), params)
 
-    def post(self, path, params):
-        return self.request.make_request("POST", self.url(path), params)
+    def post(self, path, params, cage_run = False):
+        return self.request.make_request("POST", self.url(path, cage_run), params)
 
     def put(self, path, params):
         return self.request.make_request("PUT", self.url(path), params)
@@ -41,5 +43,6 @@ class Client(object):
     def delete(self, path, params):
         return self.request.make_request("DELETE", self.url(path), params)
 
-    def url(self, path):
-        return self.base_url + path
+    def url(self, path, cage_run = False):
+        base_url = self.base_run_url if cage_run else self.base_url
+        return base_url + path

--- a/evervault/crypto/client.py
+++ b/evervault/crypto/client.py
@@ -102,8 +102,7 @@ class Client(object):
 
     def __fetch_cage_key(self, fetch):
         if self.cage_key is None:
-            print("Fetching cage key")
-            resp = fetch.get("/cages/key")
+            resp = fetch.get("cages/key")
             self.cage_key = Key(resp["key"]).key
             self.public_key = serialization.load_pem_public_key(
                 self.cage_key.encode("utf8"), backend=default_backend()


### PR DESCRIPTION
Running cages with the SDK
```python
~/ev/evervault-python jonnyom/ch2461/run-cages !2 > python                                                                                                                                                     py 3.9.0 18:30:37
Python 3.9.0 (default, Oct 19 2020, 12:56:53) 
[Clang 12.0.0 (clang-1200.0.31.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from evervault.client import Client
>>> client = Client(api_key='OTQ=:vDgYzWZyAh9Hg72ksw9Lg3QoEUMTwhrL5pxDdvB9Wwg=')
>>> client.encrypt_and_run('hello-cage-filthy-fuchsia', {'name': 'testing'}, False)
Fetching cage key
{'result': {'message': 'Hello, testing!', 'details': 'The cage is decrypting your name and returning it in plaintext - here is an update', 'encrypted': 'eyJpc3MiOiJldmVydmF1bHQiLCJ2ZXJzaW9uIjoxLCJkYXRhdHlwZSI6InN0cmluZyJ9.eyJjYWdlRGF0YSI6IngzN3FDeGpXbVY2MEdXcnhLVUhKRjd4SG9PaDVrUFRuT1dCamFqeVo4UkhwV2lzVSsyNHF3czY3UTE3OHBoWVg5SC94WEtOSThUZWt1YWo5Nms0NzhUbkh1dFJxRW4zdisrT1VmQjEyTTFqTDRvZGZaMjBnbkFRcjNjTnp6bTE4dVlURVkzaFBMeUZLbHZFUHhEQkt0bGd4bVpHeHA3S1hVT3d3U09KM3pwcmh5dWRMMGNEZFQrRDEvb1hLRUdpdjk0aGF0bmJ0VVZYMktYTW9DUkpjY3lVK1ZLN0ZMQmRhVkxYMWpNcTZXR250cXFxNm55YTczaktOUDVHcGptOUczMm9lQXEyQlE3N0xabjhUam91eW1VbDBzODIra2pFZE5UdHlsZEJ6cTBWMDJ2NVhiek1BWGF1amU3QlI4YmJHVmRNSWN5aXRKM1VGREF5OXc3Vkp1dz09Iiwia2V5SXYiOiJ2c1lzeUxHRGVQUzkwME11RUR2SnZBPT0iLCJzaGFyZWRFbmNyeXB0ZWREYXRhIjoiYnd2SGlrWER2SUg4cmF4Z293NGc4L1JDTmNCc2xSaz0ifQ==.5ceaaf93-26cd-4905-9607-463f4564feb7'}, 'runId': '7cd96665a629'}
>>> client.encrypt_and_run('hello-cage-filthy-fuchsia', {'name': 'testing'}, False)
{'result': {'message': 'Hello, testing!', 'details': 'The cage is decrypting your name and returning it in plaintext - here is an update', 'encrypted': 'eyJpc3MiOiJldmVydmF1bHQiLCJ2ZXJzaW9uIjoxLCJkYXRhdHlwZSI6InN0cmluZyJ9.eyJjYWdlRGF0YSI6Iks4ZXp6b2tURXhQeFJKQXpKVFRIMHZvS1VKS0lHa0w1WmhkZGpoYVorOVF3Y3h4cTA3UVNQZ0JlWUxlVEdpVjZETitIa21WVEFzNHZxTUhpcjYybFZlV0hORndLaGlCMTZOVzNFbWRqK3MzTmxFc0o1YXM1cmUyVmx2RjZkOHRLZVpkY2dHNEMwOUpJRTZLNXJVdVlkYjBUeXRHOFRlMEtVaGZPanR0aDJ5OWVSSGZwaTgxeURXR0VCT1UvNmVmWjZ5aEU2SndxQnAvMWxOM01XWDExWUhCb0t1N3A5c2ZadnduTnJlSWVxbFZXOXRmZTRhTmlCVENZWnYzUWFCdndRK1BBQjUvazdQY0E4U09YZmJsZFhHaC9pMEo1UmtQMDNMb2V5SiszcHZVS0pYanU1cTB1elI0RnQ4SEVUNThxSzV0bXJrMWVFaXRXQmx0WXo3bzl6Zz09Iiwia2V5SXYiOiJKMGxrVCtIYmkxUmVIZkxBYlJFclBRPT0iLCJzaGFyZWRFbmNyeXB0ZWREYXRhIjoiTC9Rb1JUQ1A4bWpSY28zUjhIWEszQW5qV0dFVkxUbz0ifQ==.84bf3884-8762-4f8e-b433-6d235c828a2d'}, 'runId': '3e6ebf089caa'}
>>> client.encrypt_and_run('hello-cage-filthy-fuchsia', {'name': 'testing'}, True)
{'result': {'message': 'Hello, testing!', 'details': 'The cage is decrypting your name and returning it in plaintext - here is an update', 'encrypted': 'eyJpc3MiOiJldmVydmF1bHQiLCJ2ZXJzaW9uIjoxLCJkYXRhdHlwZSI6InN0cmluZyJ9.eyJjYWdlRGF0YSI6ImM0Yjg4Z0p4MmtZd21Db1ZuNjhSODBoREltMGFhU0VwUDBNQSswQVhSVUxEbXZFUDFLakpYWERHWCsvMXhkbldNVjNQZGhVVEdIWVhjOUxoVmxZVStKY1VXaDE2WWdpWGpBMUlqZDBkTXJhaFBhQnhrMTgyQUI0ZExxRHBaY0ZUd1B4eFRSajhnaEFqNDJvVXh0dnRkcWhlekNiM2x4dmFKcXp3amtVUlZhQmJ2UkRwUG04aTVtZ1dEd1FNZTlkQ1l2bWVhbkZDd2J2S0FJeHRqUDBnWkpqQ292ejRxQ2o0UnY2d0RGMkdTTTRjRHdCUXVDRFh0WEpuekttRWVyVWhoT254V1FWSVFPV01mMnViRnRheW5ESXlnNi84TDBycG1Dc3VDL1czZzVEb2QwcHBTd2lYWGw3N2cwVFAyYjV6enFwdXIwK0xPK3BxdktlRXNBK0ZPQT09Iiwia2V5SXYiOiJIVndyZXlWVjl3ZFdnSlZKUjA2Tzh3PT0iLCJzaGFyZWRFbmNyeXB0ZWREYXRhIjoiS0tMdk1ZZzV3Zi9McGFIUng4KzF5TG0xVWNBb3VWMD0ifQ==.76f370cf-448a-4c34-ae23-1212cf65818e'}, 'runId': 'bdc75d0cc355'}
```

