### PR TITLE
Append cert for outbound Relay to Certifi trusted CAs file

### DIFF
--- a/evervault/client.py
+++ b/evervault/client.py
@@ -4,7 +4,7 @@ from .models.cage_list import CageList
 from .datatypes.map import ensure_is_integer
 from .errors.evervault_errors import CertDownloadError
 import requests
-import tempfile
+import certifi
 
 class Client(object):
     def __init__(
@@ -44,12 +44,17 @@ class Client(object):
     def relay(client_self):
         old_request_func = requests.Session.request
         cert_host = "https://ca.evervault.com"
-        try:
-            with tempfile.NamedTemporaryFile(delete=False) as cert_file:
-                cert_file.write(requests.get(cert_host).content)
-                cert_path = cert_file.name
-        except:
-            raise CertDownloadError("Unable to download cert for relay from {}".format(cert_host))
+        if 'Evervault' not in certifi.contents():
+            try:
+                with open(certifi.where(), 'ab') as ca_file:
+                    added_cert = bytes('\n# Evervault\n', 'ascii') + requests.get(cert_host).content
+                    ca_file.write(added_cert)
+            except:
+                raise CertDownloadError("Unable to install the Evervault root certficate from {cert_host}. "
+                    f"Likely a permissions error when trying to write to the Certifi CA at {certifi.where()}. "
+                    "You may manually append the certificate contents to the file after downloading "
+                    f"it at {cert_host}. Also add a comment \'# Evervault\' to the file to ensure "
+                    "the SDK knows it is there.")
         api_key = client_self.api_key
         relay_url = client_self.relay_url
         def new_req_func(self, method, url,
@@ -58,7 +63,6 @@ class Client(object):
                 hooks=None, stream=None, verify=None, cert=None, json=None):
             headers["Proxy-Authorization"] = api_key
             proxies["https"] = relay_url
-            verify = cert_path
             return old_request_func(self, method, url,
                 params, data, headers, cookies, files,
                 auth, timeout, allow_redirects, proxies,

--- a/evervault/client.py
+++ b/evervault/client.py
@@ -44,17 +44,17 @@ class Client(object):
     def relay(client_self):
         old_request_func = requests.Session.request
         cert_host = "https://ca.evervault.com"
-        if 'Evervault' not in certifi.contents():
-            try:
+        try:
+            cert = requests.get(cert_host).content
+            cert_already_installed = cert in bytes(certifi.contents(), 'ascii')
+            if not cert_already_installed:
                 with open(certifi.where(), 'ab') as ca_file:
-                    added_cert = bytes('\n# Evervault\n', 'ascii') + requests.get(cert_host).content
-                    ca_file.write(added_cert)
-            except:
-                raise CertDownloadError("Unable to install the Evervault root certficate from {cert_host}. "
-                    f"Likely a permissions error when trying to write to the Certifi CA at {certifi.where()}. "
-                    "You may manually append the certificate contents to the file after downloading "
-                    f"it at {cert_host}. Also add a comment \'# Evervault\' to the file to ensure "
-                    "the SDK knows it is there.")
+                    ca_file.write(cert)
+        except:
+            raise CertDownloadError(f"Unable to install the Evervault root certficate from {cert_host}. "
+                f"Likely a permissions error when trying to write to the Certifi CA at {certifi.where()}. "
+                "You may manually append the certificate contents to the file after downloading "
+                f"it at {cert_host}.")
         api_key = client_self.api_key
         relay_url = client_self.relay_url
         def new_req_func(self, method, url,

--- a/evervault/client.py
+++ b/evervault/client.py
@@ -52,9 +52,9 @@ class Client(object):
                     ca_file.write(cert)
         except:
             raise CertDownloadError(f"Unable to install the Evervault root certficate from {cert_host}. "
-                f"Likely a permissions error when trying to write to the Certifi CA at {certifi.where()}. "
-                "You may manually append the certificate contents to the file after downloading "
-                f"it at {cert_host}.")
+                f"Likely a permissions error when trying to write to the Certifi CA file at {certifi.where()}. "
+                "You may manually append the certificate contents to this file after downloading "
+                f"the certificate at {cert_host}.")
         api_key = client_self.api_key
         relay_url = client_self.relay_url
         def new_req_func(self, method, url,

--- a/evervault/version.py
+++ b/evervault/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.1.2"
+VERSION = "0.1.3"


### PR DESCRIPTION
# Why
After testing using the outbound Relay on the pypi test server I noticed that strangely the previous method for verifying the relay certificate wasn't working on `Python 3.8.10`+ versions. Latest versions of Python seem very hardcore about only using the `certifi` root CAs file.

# How
Append Evervault root CA to the `certifi` list of trusted CAs. Tested this new method on Ubuntu and Mac and it works but I included manual install instructions in the error message in case write access for the `certifi` CA file is unavailable.