### PR TITLE
Add ability to give list of domains not to send through Outbound Relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ evervault.relay()
 # all further HTTPS requests made in your program will be routed through Relay
 ```
 
+You may also optionally pass in a list of domains which you **don't** want to go through Relay, i.e. requests sent to these domains will not be decrypted.
+
+```python
+evervault.relay(['httpbin.org', 'www.facebook.com'])
+# requests sent to urls such as https://httpbin.org/post or https://api.facebook.com will not be sent through Relay
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/evervault/evervault-python.

--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -28,8 +28,8 @@ def encrypt_and_run(cage_name, data, options = { "async": False, "version": None
 def cages():
     return __client().cages()
 
-def relay():
-    __client().relay()
+def relay(ignore_domains=[]):
+    __client().relay(ignore_domains)
 
 
 def __client():

--- a/evervault/client.py
+++ b/evervault/client.py
@@ -3,8 +3,10 @@ from .crypto.client import Client as CryptoClient
 from .models.cage_list import CageList
 from .datatypes.map import ensure_is_integer
 from .errors.evervault_errors import CertDownloadError
+from urllib.parse import urlparse
 import requests
 import certifi
+import warnings
 
 class Client(object):
     def __init__(
@@ -41,7 +43,13 @@ class Client(object):
         cages = self.get("cages")["cages"]
         return CageList(cages, self).cages
 
-    def relay(client_self):
+    def relay(client_self, ignore_domains=[]):
+        ignore_if_exact = []
+        ignore_if_endswith = ()
+        for domain in ignore_domains:
+            if domain.startswith('www.'): domain = domain[4:]
+            ignore_if_exact.append(domain)
+            ignore_if_endswith += ('.' + domain, '@' + domain)
         old_request_func = requests.Session.request
         cert_host = "https://ca.evervault.com"
         try:
@@ -63,6 +71,15 @@ class Client(object):
                 hooks=None, stream=None, verify=None, cert=None, json=None):
             headers["Proxy-Authorization"] = api_key
             proxies["https"] = relay_url
+            try:
+                domain = urlparse(url).netloc
+                if domain in ignore_if_exact or domain.endswith(ignore_if_endswith):
+                    del headers["Proxy-Authorization"]
+                    del proxies["https"]
+            except Exception:
+                warnings.warn(f"Unable to parse {url} when attempting to check "
+                            "if it is an ignore_domain.")
+                pass
             return old_request_func(self, method, url,
                 params, data, headers, cookies, files,
                 auth, timeout, allow_redirects, proxies,


### PR DESCRIPTION
# Why
Clients would like the ability to give a list of target domains with the effect that requests sent to these domains won't get sent through Outbound Relay

# How
Note: current configuration works such that if a target URL sent in a request cannot be parsed, it will default to go through Relay. I figured it is highly unlikely clients would be making strange requests toward their `ignore_domains`, so better to handle the edge cases by sending them through Relay as default (I also think these edge cases may never occur because if `urlparse` can't parse it then I think this will cause further errors at lower levels).

_Readme update:_
You may also optionally pass in a list of domains which you **don't** want to go through Relay, i.e. requests sent to these domains will not be decrypted.

```python
evervault.relay(['httpbin.org', 'www.facebook.com'])
# requests sent to urls such as https://httpbin.org/post or https://api.facebook.com will not be sent through Relay
```