### PR TITLE
Make outbound relay work in python sdk

### DIFF
--- a/evervault/version.py
+++ b/evervault/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.1.4"
+VERSION = "0.1.7"


### PR DESCRIPTION
# Why
File write issues

# How
@shanecurran solved it by appending the Evervault root cert to the `certifi` trusted roots and storing in temp file (`version` is bumped by a few because I deployed a couple of times earlier without bumping repo)