### PR TITLE
Update cert install error message

### DIFF
--- a/evervault/client.py
+++ b/evervault/client.py
@@ -54,14 +54,13 @@ class Client(object):
         old_request_func = requests.Session.request
         cert_host = "https://ca.evervault.com"
         try:
+            5/0
             with tempfile.NamedTemporaryFile(delete=False) as cert_file:
                 cert_file.write(bytes(certifi.contents(), 'ascii') + requests.get(cert_host).content)
                 cert_path = cert_file.name
         except:
             raise CertDownloadError(f"Unable to install the Evervault root certficate from {cert_host}. "
-                f"Likely a permissions error when trying to write to the Certifi CA file at {certifi.where()}. "
-                "You may manually append the certificate contents to this file after downloading "
-                f"the certificate at {cert_host}.")
+                "Likely a permissions error when attempting to write to the /tmp/ directory.")
         api_key = client_self.api_key
         relay_url = client_self.relay_url
         def new_req_func(self, method, url,

--- a/evervault/client.py
+++ b/evervault/client.py
@@ -54,7 +54,6 @@ class Client(object):
         old_request_func = requests.Session.request
         cert_host = "https://ca.evervault.com"
         try:
-            5/0
             with tempfile.NamedTemporaryFile(delete=False) as cert_file:
                 cert_file.write(bytes(certifi.contents(), 'ascii') + requests.get(cert_host).content)
                 cert_path = cert_file.name

--- a/evervault/version.py
+++ b/evervault/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.1.7"
+VERSION = "0.1.8"


### PR DESCRIPTION
# Why
Remembered that I forgot to update the error message :unamused:

# How
`Unable to install the Evervault root certficate from {cert_host}. Likely a permissions error when attempting to write to the /tmp/ directory.`