### PR TITLE
Dont send requests to cages through Relay (Python SDK)

### DIFF
--- a/evervault/client.py
+++ b/evervault/client.py
@@ -45,6 +45,7 @@ class Client(object):
         return CageList(cages, self).cages
 
     def relay(client_self, ignore_domains=[]):
+        ignore_domains.append(urlparse(client_self.base_run_url).netloc)
         ignore_if_exact = []
         ignore_if_endswith = ()
         for domain in ignore_domains:

--- a/evervault/version.py
+++ b/evervault/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.1.8"
+VERSION = "0.1.9"


### PR DESCRIPTION
# Why
Data should only be decrypted when it reaches the cage

# How
```python
ignore_domains.append(urlparse(client_self.base_run_url).netloc)
```