### PR TITLE
Deirdre/eng 1051 add new encrypted string format to

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For full installation support, [book time here](https://calendly.com/evervault/c
 
 ## Documentation
 
-See the Evervault [Python SDK documentation](https://docs.evervault.com/python).
+See the Evervault [Python SDK documentation](https://docs.evervault.com/sdk/python).
 
 ## Installation
 

--- a/evervault/crypto/client.py
+++ b/evervault/crypto/client.py
@@ -19,8 +19,7 @@ class Client(object):
         self.generated_ecdh_key = None
         self.shared_key = None
         self.start_time = int(time.time())
-        base64_ev_version = self.__base_64_remove_padding(base64.b64encode(bytes(EV_VERSION, "utf8")).decode("utf"))
-        self.ev_version_prefix = f":{base64_ev_version}" if base64_ev_version != "" else ""
+        self.ev_version = self.__base_64_remove_padding(base64.b64encode(bytes(EV_VERSION, "utf8")).decode("utf"))
 
     def encrypt_data(self, fetch, data):
         if data is None:
@@ -98,7 +97,7 @@ class Client(object):
 
     def __format(self, header, iv, public_key, encrypted_payload):
         prefix = f":{header}" if header != "string" else ""
-        return f"ev{self.ev_version_prefix}{prefix}:{self.__base_64_remove_padding(iv)}:{self.__base_64_remove_padding(public_key)}:{self.__base_64_remove_padding(encrypted_payload)}:$"
+        return f"ev:{self.ev_version}{prefix}:{self.__base_64_remove_padding(iv)}:{self.__base_64_remove_padding(public_key)}:{self.__base_64_remove_padding(encrypted_payload)}:$"
 
     def __base_64_remove_padding(self, data):
         return data.rstrip("=")

--- a/evervault/crypto/client.py
+++ b/evervault/crypto/client.py
@@ -7,6 +7,7 @@ from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from secrets import token_bytes
 import base64
 import time 
+from .version import EV_VERSION
 
 BS = 32
 KEY_INTERVAL = 15
@@ -18,6 +19,8 @@ class Client(object):
         self.generated_ecdh_key = None
         self.shared_key = None
         self.start_time = int(time.time())
+        base64_ev_version = self.__base_64_remove_padding(base64.b64encode(bytes(EV_VERSION, "utf8")).decode("utf"))
+        self.ev_version_prefix = f":{base64_ev_version}" if base64_ev_version != "" else ""
 
     def encrypt_data(self, fetch, data):
         if data is None:
@@ -95,7 +98,7 @@ class Client(object):
 
     def __format(self, header, iv, public_key, encrypted_payload):
         prefix = f":{header}" if header != "string" else ""
-        return f"ev{prefix}:{self.__base_64_remove_padding(iv)}:{self.__base_64_remove_padding(public_key)}:{self.__base_64_remove_padding(encrypted_payload)}:$"
+        return f"ev{self.ev_version_prefix}{prefix}:{self.__base_64_remove_padding(iv)}:{self.__base_64_remove_padding(public_key)}:{self.__base_64_remove_padding(encrypted_payload)}:$"
 
     def __base_64_remove_padding(self, data):
         return data.rstrip("=")

--- a/evervault/crypto/version.py
+++ b/evervault/crypto/version.py
@@ -1,1 +1,1 @@
-EV_VERSION = ""
+EV_VERSION = "DUB"

--- a/evervault/crypto/version.py
+++ b/evervault/crypto/version.py
@@ -1,0 +1,1 @@
+EV_VERSION = ""

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -5,6 +5,7 @@ import base64
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 import evervault
+from evervault.crypto.version import EV_VERSION
 
 class TestEvervault(unittest.TestCase):
     def setUp(self):
@@ -173,14 +174,15 @@ class TestEvervault(unittest.TestCase):
         return (base64.b64encode(key))
 
     def __is_evervault_string(self, data, type):
+        ev_version_configured = EV_VERSION == ""
         parts = data.split(":")
         if len(parts) < 5:
             return False
         elif type == "string":
-            return len(parts) == 5
-        elif type != "string" and len(parts) < 6:
-            return False    
-        elif type != parts[1]:
+            return len(parts) == 5 if ev_version_configured else len(parts) == 6
+        elif type != "string" and not (len(parts) == 6 if ev_version_configured else len(parts) == 7):
+            return False
+        elif type != parts[1] if ev_version_configured else type != parts[2]:
             return False
         return True
 

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -5,7 +5,6 @@ import base64
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 import evervault
-from evervault.crypto.version import EV_VERSION
 
 class TestEvervault(unittest.TestCase):
     def setUp(self):
@@ -174,15 +173,14 @@ class TestEvervault(unittest.TestCase):
         return (base64.b64encode(key))
 
     def __is_evervault_string(self, data, type):
-        ev_version_configured = EV_VERSION == ""
         parts = data.split(":")
-        if len(parts) < 5:
+        if len(parts) < 6:
             return False
         elif type == "string":
-            return len(parts) == 5 if ev_version_configured else len(parts) == 6
-        elif type != "string" and not (len(parts) == 6 if ev_version_configured else len(parts) == 7):
+            return len(parts) == 6
+        elif type != "string" and not len(parts) == 7:
             return False
-        elif type != parts[1] if ev_version_configured else type != parts[2]:
+        elif type != parts[2]:
             return False
         return True
 


### PR DESCRIPTION
# Why
We need to handle the new encrypted string format as discussed in the Duplicate Data doc

# How
Added new version prefix to the string to match the following format:
ev:[version]:[datatype]:Base64(KeyIV):Base64(ECDHPublicKey):Base64(AESEncryptedData):$