### PR TITLE
Override proxy rebuild method to fix API key being removed from requests

### DIFF
--- a/evervault/client.py
+++ b/evervault/client.py
@@ -63,6 +63,14 @@ class Client(object):
                 "Likely a permissions error when attempting to write to the /tmp/ directory.")
         api_key = client_self.api_key
         relay_url = client_self.relay_url
+
+        # We override this method to stop the requests library from 
+        # removing the API token from the Proxy-Authorization header
+        def rebuild_proxies(self, prepared_request, proxies):
+          pass
+
+        requests.sessions.SessionRedirectMixin.rebuild_proxies = rebuild_proxies
+
         def new_req_func(self, method, url,
                 params=None, data=None, headers={}, cookies=None, files=None,
                 auth=None, timeout=None, allow_redirects=True, proxies={},


### PR DESCRIPTION
# Why

There was an issue in requests 2.26.0 where a function `rebuild_proxies` was called before a request, which caused the `Proxy-Authorization` header to be removed (since it is not password based). 

# How

This function has just been overriden to do nothing, since all of its functions are already handled on our side.