### PR TITLE
Default outbound relay to ON in Python SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Evervault Python SDK
 
-The [Evervault](https://evervault.com) Python SDK is a toolkit for encrypting data as it enters your server, and working with Cages. By default, initializing the SDK will result in all outbound HTTPS requests being intercepted by Relay – and decrypted.
+The [Evervault](https://evervault.com) Python SDK is a toolkit for encrypting data as it enters your server, and working with Cages. By default, initializing the SDK will result in all outbound HTTPS requests being intercepted and decrypted.
 
 ## Getting Started
 
@@ -44,7 +44,7 @@ The Evervault Python SDK exposes five functions.
 
 ### evervault.init()
 
-`evervault.init()` initializes the SDK with your API key. Configurations for Relay's interception of outbound requests may also be passed in this function.
+`evervault.init()` initializes the SDK with your API key. Configurations for the interception of outbound requests may also be passed in this function.
 
 ```python
 evervault.init(api_key = str[, intercept = bool, ignore_domains = list])
@@ -53,8 +53,8 @@ evervault.init(api_key = str[, intercept = bool, ignore_domains = list])
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | api_key | `str` | The API key of your Evervault Team |
-| intercept | `bool` | Decides if outbound requests are intercepted by Relay (`true` by default) |
-| ignore_domains | `list(str)` | Requests sent to any of the domains in this list will not be intercepted by Relay |
+| intercept | `bool` | Decides if outbound requests are intercepted (`true` by default) |
+| ignore_domains | `list(str)` | Requests sent to any of the domains in this list will not be intercepted |
 
 ### evervault.encrypt()
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ evervault.init(api_key = str[, intercept = bool, ignore_domains = list])
 | --------- | ---- | ----------- |
 | api_key | `str` | The API key of your Evervault Team |
 | intercept | `bool` | Decides if outbound requests are intercepted by Relay (`true` by default) |
-| ignore_domains | `list of strings` | Requests sent to any of the domains in this list will not be intercepted by Relay |
+| ignore_domains | `list(str)` | Requests sent to any of the domains in this list will not be intercepted by Relay |
 
 ### evervault.encrypt()
 
@@ -106,26 +106,6 @@ evervault.encrypt_and_run(cageName = str, data = dict[, options = dict])
 ### evervault.cages()
 
 Return a `dict` of your team's Cage objects in `dict` format, with `cage-name` as keys.
-
-### Disable Relay interception on requests to specfic domains
-
-You may pass in a list of domains which you **don't** want to be intercepted by Relay, i.e. requests sent to these domains will not go through Relay, and hence will not be decrypted. This array is list in the `ignoreDomains` parameter.
-
-### evervault.relay()
-
-You may configure the SDK to automatically route all outbound HTTPS requests through [Relay](https://docs.evervault.com/product/relay) by calling the `relay()` function. This currently supports requests made using the popular [`requests`](https://docs.python-requests.org/en/master/) package.
-
-```python
-evervault.relay()
-# all further HTTPS requests made in your program will be routed through Relay
-```
-
-You may also optionally pass in a list of domains which you **don't** want to go through Relay, i.e. requests sent to these domains will not be decrypted.
-
-```python
-evervault.relay(['httpbin.org', 'www.facebook.com'])
-# requests sent to urls such as https://httpbin.org/post or https://api.facebook.com will not be sent through Relay
-```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Evervault Python SDK
 
-The [Evervault](https://evervault.com) Python SDK is a toolkit for encrypting data as it enters your server, and working with Cages.
+The [Evervault](https://evervault.com) Python SDK is a toolkit for encrypting data as it enters your server, and working with Cages. By default, initializing the SDK will result in all outbound HTTPS requests being intercepted by Relay – and decrypted.
 
 ## Getting Started
 
@@ -32,7 +32,7 @@ To make Evervault available for use in your app:
 import evervault
 
 # Initialize the client with your team's api key
-evervault.api_key = <YOUR-API-KEY>
+evervault.init('<YOUR-API-KEY>')
 
 # Encrypt your data and run a cage
 result = evervault.encrypt_and_run(<CAGE-NAME>, { 'hello': 'World!' })
@@ -41,6 +41,20 @@ result = evervault.encrypt_and_run(<CAGE-NAME>, { 'hello': 'World!' })
 ## Reference
 
 The Evervault Python SDK exposes five functions.
+
+### evervault.init()
+
+`evervault.init()` initializes the SDK with your API key. Configurations for Relay's interception of outbound requests may also be passed in this function.
+
+```python
+evervault.init(api_key = str[, intercept = bool, ignore_domains = list])
+```
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| api_key | `str` | The API key of your Evervault Team |
+| intercept | `bool` | Decides if outbound requests are intercepted by Relay (`true` by default) |
+| ignore_domains | `list of strings` | Requests sent to any of the domains in this list will not be intercepted by Relay |
 
 ### evervault.encrypt()
 
@@ -92,6 +106,10 @@ evervault.encrypt_and_run(cageName = str, data = dict[, options = dict])
 ### evervault.cages()
 
 Return a `dict` of your team's Cage objects in `dict` format, with `cage-name` as keys.
+
+### Disable Relay interception on requests to specfic domains
+
+You may pass in a list of domains which you **don't** want to be intercepted by Relay, i.e. requests sent to these domains will not go through Relay, and hence will not be decrypted. This array is list in the `ignoreDomains` parameter.
 
 ### evervault.relay()
 

--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -6,11 +6,18 @@ from .errors.evervault_errors import AuthenticationError
 __version__ = VERSION
 
 ev_client = None
-api_key = None
+_api_key = None
 request_timeout = 30
 base_url = "https://api.evervault.com/"
 base_run_url = "https://run.evervault.com/"
 relay_url="https://relay.evervault.com:443"
+
+
+def init(api_key, intercept = True, ignore_domains=[]):
+    global _api_key
+    _api_key = api_key
+    if intercept:
+        __client().relay(ignore_domains)
 
 
 def run(cage_name, encrypted_data, options = { "async": False, "version": None }):
@@ -28,17 +35,14 @@ def encrypt_and_run(cage_name, data, options = { "async": False, "version": None
 def cages():
     return __client().cages()
 
-def relay(ignore_domains=[]):
-    __client().relay(ignore_domains)
-
 
 def __client():
-    if not api_key:
+    if not _api_key:
         raise AuthenticationError("Please enter your team's API Key")
     global ev_client
     if not ev_client:
         ev_client = Client(
-            api_key=api_key,
+            api_key=_api_key,
             request_timeout=request_timeout,
             base_url=base_url,
             base_run_url=base_run_url,

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -9,7 +9,7 @@ import evervault
 class TestEvervault(unittest.TestCase):
     def setUp(self):
         self.evervault = evervault
-        self.evervault.api_key = "testing"
+        self.evervault.init("testing", intercept=False)
         self.public_key = self.build_keys()
 
     def tearDown(self):


### PR DESCRIPTION
# Why
Easier for users to integrate their API with Evervault. Just point Relay at their API and initialize the SDK in their API.

# How
* Switch to using `evervault.init('<YOUR-API-KEY>')` function instead of setting `evervault.api_key='<YOUR-API-KEY>'`. This allows us to choose whether to use Relay when the SDK is initialized. Also more similar to Node SDK.
* Switch to using `intercept = False` as the parameter to turn off Relay intercepting requests. `evervault.init('<YOUR-API-KEY>', intercept=False)`
* `ignore_domains` can be passed in `evervault.init` also: `evervault.init('<YOUR-API-KEY>', ignore_domains=['httpbin.org'])`