### PR TITLE
Return better error message when user doesn't enter API key

### DIFF
--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -38,7 +38,9 @@ def cages():
 
 def __client():
     if not _api_key:
-        raise AuthenticationError("Please enter your team's API Key")
+        raise AuthenticationError(
+            "Your Team's API Key must be entered using evervault.init('<API-KEY>')"
+        )
     global ev_client
     if not ev_client:
         ev_client = Client(


### PR DESCRIPTION
# Why
Old error message wasn't informative. This will also help users to know what to do when updating from `evervault.api_key` -> `evervault.init()`

# How
`"Your Team's API Key must be entered using evervault.init('<API-KEY>')"`