### PR TITLE
Correcting encrypt_and_run method call in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ evervault.run(cageName = str, payload = dict[, options = dict])
 | async   | `Boolean` | `False` | Run your Cage in async mode. Async Cage runs will be queued for processing.          |
 | version | `Integer` | `None`  | Specify the version of your Cage to run. By default, the latest version will be run. |
 
-### evervault.encryptAndRun()
+### evervault.encrypt_and_run()
 
-`evervault.encryptAndRun()` encrypts data and uses it as the payload to invoke the Cage.
+`evervault.encrypt_and_run()` encrypts data and uses it as the payload to invoke the Cage.
 
 ```python
 evervault.encrypt_and_run(cageName = str, data = dict[, options = dict])


### PR DESCRIPTION
# Why
Method call was in camel case

# How
Updated to lower case with underscores per example and source code