### PR TITLE
Add Metrics to Encrypt Calls

### DIFF
--- a/evervault/client.py
+++ b/evervault/client.py
@@ -47,6 +47,7 @@ class Client(object):
     def relay(client_self, ignore_domains=[]):
         ignore_domains.append(urlparse(client_self.base_run_url).netloc)
         ignore_domains.append('ca.evervault.com')
+        ignore_domains.append('metrics.evervault.com')
         ignore_if_exact = []
         ignore_if_endswith = ()
         for domain in ignore_domains:

--- a/evervault/crypto/client.py
+++ b/evervault/crypto/client.py
@@ -1,3 +1,4 @@
+from ..http.metrics import report_metric
 from ..errors.evervault_errors import UndefinedDataError, InvalidPublicKeyError, MissingTeamEcdhKey, UnknownEncryptType
 from ..datatypes.map import map_header_type
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -73,6 +74,8 @@ class Client(object):
         return encrypted_set
 
     def __encrypt_string(self, data):
+        report_metric()
+
         header_type = map_header_type(data)
         coerced_data = self.__coerce_type(data) 
         iv = token_bytes(12)

--- a/evervault/http/metrics.py
+++ b/evervault/http/metrics.py
@@ -1,0 +1,24 @@
+import requests
+import json
+import time
+import threading
+import queue
+
+METRICS_URL = 'https://metrics.evervault.com'
+
+metric_event_queue = queue.Queue()
+
+
+def worker():
+    while True:
+        data = metric_send_queue.get()
+        requests.post(METRICS_URL, data=json.dumps(data))
+        metric_send_queue.task_done()
+
+
+# Thread to post metrics without blocking
+threading.Thread(target=worker, daemon=True).start()
+
+
+def report_metric():
+    metric_event_queue.put({"data": "Data Encrypted"})

--- a/evervault/http/metrics.py
+++ b/evervault/http/metrics.py
@@ -11,9 +11,9 @@ metric_event_queue = queue.Queue()
 
 def worker():
     while True:
-        data = metric_send_queue.get()
+        data = metric_event_queue.get()
         requests.post(METRICS_URL, data=json.dumps(data))
-        metric_send_queue.task_done()
+        metric_event_queue.task_done()
 
 
 # Thread to post metrics without blocking


### PR DESCRIPTION
# Why

Currently we have no way of knowing how many fields are getting encrypted using the Evervault

# How

Adds a call to the metrics endpoint with a Data Encrypted event. This is done by creating a thread which sends off requests that are reported to a queue. Note that if the program ends before all of the request is complete, the queue will not necessarily be empty.