### PR TITLE
Support overrides of evervault endpoints via env variables

### DIFF
--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -2,16 +2,18 @@
 from .client import Client
 from .version import VERSION
 from .errors.evervault_errors import AuthenticationError
+import os
 
 __version__ = VERSION
 
 ev_client = None
 _api_key = None
 request_timeout = 30
-base_url = "https://api.evervault.com/"
-base_run_url = "https://run.evervault.com/"
-relay_url="https://relay.evervault.com:443"
 
+BASE_URL_DEFAULT = "https://api.evervault.com/"
+BASE_RUN_URL_DEFAULT = "https://run.evervault.com/"
+RELAY_URL_DEFAULT = "https://relay.evervault.com:443"
+CA_HOST_DEFAULT = "https://ca.evervault.com"
 
 def init(api_key, intercept = True, ignore_domains=[]):
     global _api_key
@@ -46,9 +48,10 @@ def __client():
         ev_client = Client(
             api_key=_api_key,
             request_timeout=request_timeout,
-            base_url=base_url,
-            base_run_url=base_run_url,
-            relay_url=relay_url,
+            base_url=os.environ.get("EV_API_URL", BASE_URL_DEFAULT),
+            base_run_url=os.environ.get("EV_CAGE_RUN_URL", BASE_RUN_URL_DEFAULT),
+            relay_url=os.environ.get("EV_TUNNEL_HOSTNAME", RELAY_URL_DEFAULT),
+            ca_host=os.environ.get("EV_CERT_HOSTNAME", CA_HOST_DEFAULT)
         )
         return ev_client
     else:

--- a/evervault/version.py
+++ b/evervault/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.2.2"
+VERSION = "0.2.4"

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -5,6 +5,7 @@ import base64
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 import evervault
+import os
 
 class TestEvervault(unittest.TestCase):
     def setUp(self):
@@ -13,7 +14,12 @@ class TestEvervault(unittest.TestCase):
         self.public_key = self.build_keys()
 
     def tearDown(self):
+        self.evervault.ev_client = None
         self.evervault = None
+        self.__del_env_var("EV_API_URL")
+        self.__del_env_var("EV_CAGE_RUN_URL")
+        self.__del_env_var("EV_TUNNEL_HOSTNAME")
+        self.__del_env_var("EV_CERT_HOSTNAME")
 
     @requests_mock.Mocker()
     def test_encrypting_number_generates_ev_number_type(self, mock_request):
@@ -44,7 +50,7 @@ class TestEvervault(unittest.TestCase):
         assert len(level_1_set_encrypted) == 3
         for item in level_1_set_encrypted:
             assert self.__is_evervault_string_format(item)
-    
+
     @requests_mock.Mocker()
     def test_encrypt_lists_of_various_types(self, mock_request):
         self.mock_fetch_cage_key(mock_request)
@@ -60,10 +66,10 @@ class TestEvervault(unittest.TestCase):
             if type(item) == list or type(item) == set:
                 for sub_item in item:
                     assert self.__is_evervault_string_format(sub_item)
-            else:        
+            else:
                 assert self.__is_evervault_string_format(item)
-        
-    
+
+
     @requests_mock.Mocker()
     def test_encrypt_dicts(self, mock_request):
         self.mock_fetch_cage_key(mock_request)
@@ -82,7 +88,7 @@ class TestEvervault(unittest.TestCase):
         assert "dict" in encrypted_data
         assert type(encrypted_data["dict"]) == dict
         assert self.__is_evervault_string(encrypted_data["dict"]["subnumber"], "number")
-    
+
     @requests_mock.Mocker()
     def test_encrypt_with_unsupported_type_throws_exception(self, mock_request):
         self.mock_fetch_cage_key(mock_request)
@@ -92,7 +98,7 @@ class TestEvervault(unittest.TestCase):
         test_instance = MyTestClass()
         level_1_list = ['a', test_instance, 3]
         level_2_list = ['a', ['a', test_instance]]
-        
+
         self.assertRaises(UnknownEncryptType, self.evervault.encrypt, test_instance)
         self.assertRaises(UnknownEncryptType, self.evervault.encrypt, level_1_list)
         self.assertRaises(UnknownEncryptType, self.evervault.encrypt, level_2_list)
@@ -144,12 +150,40 @@ class TestEvervault(unittest.TestCase):
             json={"status": "queued"},
             request_headers={ "Api-Key": "testing", "x-version-id": "2", "x-async": "true" },
         )
+        self.mock_fetch_cage_key(mock_request)
         resp = self.evervault.encrypt_and_run("testing-cage", {"name": "testing"}, {"async": True, "version": 2})
         assert request.called
         assert resp["status"] == "queued"
         assert request.last_request.json() != {"name": "testing"}
         assert request.last_request.headers["x-async"] == "true"
         assert request.last_request.headers["x-version-id"] == "2"
+
+    @requests_mock.Mocker()
+    def test_endpoint_overrides(self, mock_request):
+        mock_request.get("https://ca.evervault.com", {})
+        mock_request.get("https://ca.url.com",{})
+
+        # Test default values
+        self.evervault.init("testing", intercept=True)
+        assert self.evervault.ev_client.base_url == "https://api.evervault.com/"
+        assert self.evervault.ev_client.base_run_url == "https://run.evervault.com/"
+        assert self.evervault.ev_client.relay_url == "https://relay.evervault.com:443"
+        assert self.evervault.ev_client.ca_host == "https://ca.evervault.com"
+
+        # Set overrides
+        os.environ['EV_API_URL'] = "https://custom.url.com"
+        os.environ['EV_CAGE_RUN_URL'] = "https://custom.run.url.com"
+        os.environ['EV_TUNNEL_HOSTNAME'] = "https://custom.tunnel.url.com"
+        os.environ['EV_CERT_HOSTNAME'] = "https://ca.url.com"
+
+        # Force client to reinit
+        self.evervault.ev_client = None
+        self.evervault.init("testing")
+
+        assert self.evervault.ev_client.base_url == "https://custom.url.com"
+        assert self.evervault.ev_client.base_run_url == "https://custom.run.url.com"
+        assert self.evervault.ev_client.relay_url == "https://custom.tunnel.url.com"
+        assert self.evervault.ev_client.ca_host == "https://ca.url.com"
 
     def mock_fetch_cage_key(self, mock_request):
         mock_request.get(
@@ -158,7 +192,7 @@ class TestEvervault(unittest.TestCase):
                 "ecdhKey": self.public_key.decode("utf8")
             },
         )
-    
+
     def build_keys(self):
         ecdh_private_key = ec.generate_private_key(
             ec.SECP256K1()
@@ -169,8 +203,12 @@ class TestEvervault(unittest.TestCase):
             encoding=serialization.Encoding.X962,
             format=serialization.PublicFormat.CompressedPoint
         )
-        
+
         return (base64.b64encode(key))
+
+    def __del_env_var(self, var):
+        if var in os.environ:
+            os.environ.pop(var)
 
     def __is_evervault_string(self, data, type):
         parts = data.split(":")
@@ -190,4 +228,4 @@ class TestEvervault(unittest.TestCase):
             return False
         if parts[1] == "number" or parts[1] == "boolean":
             return len(parts) == 6
-        return True    
+        return True


### PR DESCRIPTION
# Why
Support custom non production endpoints for development and load testing

# How
Check for the presence of EV_API_URL, EV_CAGE_RUN_URL and EV_TUNNEL_HOSTNAME else use the default production values

port of https://github.com/evervault/evervault-node/pull/59