### PR TITLE
Add Encrypt Metrics Reporting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run Lints
         run: |
           poetry run black -v --check .
-          poetry run flake8 -v --ignore=E501,W503
+          poetry run flake8 -v --ignore=E501,W503,E722
       - name: Run Tests
         run: |
           poetry run pytest -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run Lints
         run: |
           poetry run black -v --check .
-          poetry run flake8 -v --ignore=E501,W503
+          poetry run flake8 -v --ignore=E501,W503,E722
       - name: Run Tests
         run: |
           poetry run pytest -v

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,4 +9,4 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/everva
 - `poetry install`
 - `poetry run pytest`
 - `poetry run black .`
-- `poetry run flake8 --ignore=E501,W503`
+- `poetry run flake8 --ignore=E501,W503,E722`

--- a/evervault/client.py
+++ b/evervault/client.py
@@ -26,7 +26,7 @@ class Client(object):
         self.relay_url = relay_url
         self.ca_host = ca_host
         self.request = Request(self.api_key, request_timeout)
-        self.crypto_client = CryptoClient()
+        self.crypto_client = CryptoClient(api_key)
 
     @property
     def _auth(self):
@@ -51,6 +51,7 @@ class Client(object):
 
     def relay(client_self, ignore_domains=[]):
         ignore_domains.append(urlparse(client_self.base_run_url).netloc)
+        ignore_domains.append(urlparse(client_self.base_url).netloc)
         ignore_domains.append(urlparse(client_self.ca_host).netloc)
         ignore_if_exact = []
         ignore_if_endswith = ()

--- a/evervault/crypto/client.py
+++ b/evervault/crypto/client.py
@@ -1,3 +1,4 @@
+from ..http.metrics import report_metric
 from ..errors.evervault_errors import (
     UndefinedDataError,
     InvalidPublicKeyError,
@@ -19,12 +20,13 @@ KEY_INTERVAL = 15
 
 
 class Client(object):
-    def __init__(self):
+    def __init__(self, api_key=None):
         self.public_key = None
         self.team_ecdh_key = None
         self.generated_ecdh_key = None
         self.shared_key = None
         self.start_time = int(time.time())
+        self.api_key = api_key
         self.ev_version = self.__base_64_remove_padding(
             base64.b64encode(bytes(EV_VERSION, "utf8")).decode("utf")
         )
@@ -81,6 +83,8 @@ class Client(object):
         return encrypted_set
 
     def __encrypt_string(self, data):
+        report_metric(self.api_key)
+
         header_type = map_header_type(data)
         coerced_data = self.__coerce_type(data)
         iv = token_bytes(12)

--- a/evervault/http/metrics.py
+++ b/evervault/http/metrics.py
@@ -1,0 +1,34 @@
+import requests
+import threading
+import queue
+import evervault
+import os
+
+
+def post_metric(api_key, count):
+    # api_url = os.environ.get("EV_API_URL", evervault.BASE_URL_DEFAULT)
+    api_url = 'https://api.evervault.io/' # During development use the staging server
+    url = f'{api_url}metrics/sdkEncryptions?sdk=python&numEncryptions={count}'
+
+    headers = { 'Api-Key': api_key }
+    return requests.post(url, headers=headers)
+        
+
+metric_event_queue = queue.Queue()
+
+def worker():
+    while True:
+        # try:
+        data = metric_event_queue.get()
+
+        a = post_metric(data['api_key'], 1)
+        
+        metric_event_queue.task_done()
+        # except:
+        #     pass
+
+# Thread to post metrics without blocking
+threading.Thread(target=worker, daemon=True).start()
+
+def report_metric(api_key):
+    metric_event_queue.put({"data": "Data Encrypted", "api_key": api_key})

--- a/evervault/http/metrics.py
+++ b/evervault/http/metrics.py
@@ -1,8 +1,39 @@
+import atexit
 import requests
 import threading
 import queue
 import evervault
 import os
+
+
+class ReportingScheduler(object):
+    def __init__(self, interval, function):
+        self.interval = interval
+        self.function = function
+        self.running = False
+        self._timer = None
+
+    def __call__(self):
+        self.running = False
+        self.start()
+        self.function()
+
+    def start(self):
+        if self.running:
+            return
+
+        self._timer = threading.Timer(self.interval, self)
+        self._timer.start()
+        self.running = True
+
+    def stop(self):
+        if self._timer:
+            self._timer.cancel()
+        self.running = False
+        self._timer = None
+
+
+metric_event_queue = queue.Queue()
 
 
 def post_metric(api_key, count):
@@ -13,24 +44,46 @@ def post_metric(api_key, count):
     return requests.post(url, headers=headers)
 
 
-metric_event_queue = queue.Queue()
+def metric_report_schedule_manager():
+    scheduler = ReportingScheduler(0.001, worker)
+    scheduler.start()
 
 
 def worker():
-    while True:
-        # try:
+    encrypt_metric_batches = []
+
+    current_api_key = None
+    encrypt_count = 0
+
+    while not metric_event_queue.empty():
         data = metric_event_queue.get()
 
-        post_metric(data["api_key"], 1)
+        if current_api_key is not None and current_api_key != data["api_key"]:
+            encrypt_metric_batches.append((current_api_key, encrypt_count))
 
+        if current_api_key != data["api_key"]:
+            current_api_key = data["api_key"]
+            encrypt_count = 0
+
+        encrypt_count += 1
         metric_event_queue.task_done()
-        # except:
-        #     pass
+
+    encrypt_metric_batches.append((current_api_key, encrypt_count))
+
+    for (api_key, count) in encrypt_metric_batches:
+        try:
+            post_metric(api_key, count)
+        except:
+            pass
 
 
-# Thread to post metrics without blocking
-threading.Thread(target=worker, daemon=True).start()
+threading.Thread(target=metric_report_schedule_manager, daemon=True).start()
 
 
 def report_metric(api_key):
-    metric_event_queue.put({"data": "Data Encrypted", "api_key": api_key})
+    metric_event_queue.put({"api_key": api_key})
+
+
+@atexit.register
+def end_metrics_reporting():
+    worker()

--- a/evervault/http/metrics.py
+++ b/evervault/http/metrics.py
@@ -7,28 +7,31 @@ import os
 
 def post_metric(api_key, count):
     # api_url = os.environ.get("EV_API_URL", evervault.BASE_URL_DEFAULT)
-    api_url = 'https://api.evervault.io/' # During development use the staging server
-    url = f'{api_url}metrics/sdkEncryptions?sdk=python&numEncryptions={count}'
+    api_url = "https://api.evervault.io/"  # During development use the staging server
+    url = f"{api_url}metrics/sdkEncryptions?sdk=python&numEncryptions={count}"
 
-    headers = { 'Api-Key': api_key }
+    headers = {"Api-Key": api_key}
     return requests.post(url, headers=headers)
-        
+
 
 metric_event_queue = queue.Queue()
+
 
 def worker():
     while True:
         # try:
         data = metric_event_queue.get()
 
-        a = post_metric(data['api_key'], 1)
-        
+        a = post_metric(data["api_key"], 1)
+
         metric_event_queue.task_done()
         # except:
         #     pass
 
+
 # Thread to post metrics without blocking
 threading.Thread(target=worker, daemon=True).start()
+
 
 def report_metric(api_key):
     metric_event_queue.put({"data": "Data Encrypted", "api_key": api_key})

--- a/evervault/http/metrics.py
+++ b/evervault/http/metrics.py
@@ -6,8 +6,7 @@ import os
 
 
 def post_metric(api_key, count):
-    # api_url = os.environ.get("EV_API_URL", evervault.BASE_URL_DEFAULT)
-    api_url = "https://api.evervault.io/"  # During development use the staging server
+    api_url = os.environ.get("EV_API_URL", evervault.BASE_URL_DEFAULT)
     url = f"{api_url}metrics/sdkEncryptions?sdk=python&numEncryptions={count}"
 
     headers = {"Api-Key": api_key}
@@ -22,7 +21,7 @@ def worker():
         # try:
         data = metric_event_queue.get()
 
-        a = post_metric(data["api_key"], 1)
+        post_metric(data["api_key"], 1)
 
         metric_event_queue.task_done()
         # except:

--- a/evervault/http/metrics.py
+++ b/evervault/http/metrics.py
@@ -45,7 +45,7 @@ def post_metric(api_key, count):
 
 
 def metric_report_schedule_manager():
-    scheduler = ReportingScheduler(0.001, worker)
+    scheduler = ReportingScheduler(1.5, worker)
     scheduler.start()
 
 
@@ -71,10 +71,11 @@ def worker():
     encrypt_metric_batches.append((current_api_key, encrypt_count))
 
     for (api_key, count) in encrypt_metric_batches:
-        try:
-            post_metric(api_key, count)
-        except:
-            pass
+        if count > 0:
+            try:
+                post_metric(api_key, count)
+            except:
+                pass
 
 
 threading.Thread(target=metric_report_schedule_manager, daemon=True).start()

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -25,6 +25,8 @@ class TestEvervault(unittest.TestCase):
     @requests_mock.Mocker()
     def test_encrypting_number_generates_ev_number_type(self, mock_request):
         self.mock_fetch_cage_key(mock_request)
+        self.mock_metrics_endpoint(mock_request)
+
         input = 1
         encrypted_input = self.evervault.encrypt(input)
         assert self.__is_evervault_string(encrypted_input, "number")
@@ -32,6 +34,8 @@ class TestEvervault(unittest.TestCase):
     @requests_mock.Mocker()
     def test_encrypting_boolean_generates_ev_boolean_type(self, mock_request):
         self.mock_fetch_cage_key(mock_request)
+        self.mock_metrics_endpoint(mock_request)
+
         input = False
         encrypted_input = self.evervault.encrypt(input)
         assert self.__is_evervault_string(encrypted_input, "boolean")
@@ -39,6 +43,8 @@ class TestEvervault(unittest.TestCase):
     @requests_mock.Mocker()
     def test_encrypting_string_generates_ev_string_type(self, mock_request):
         self.mock_fetch_cage_key(mock_request)
+        self.mock_metrics_endpoint(mock_request)
+
         input = "string"
         encrypted_input = self.evervault.encrypt(input)
         assert self.__is_evervault_string(encrypted_input, "string")
@@ -46,6 +52,8 @@ class TestEvervault(unittest.TestCase):
     @requests_mock.Mocker()
     def test_encrypt_sets(self, mock_request):
         self.mock_fetch_cage_key(mock_request)
+        self.mock_metrics_endpoint(mock_request)
+
         level_1_set = set(["a", True, 3])
         level_1_set_encrypted = self.evervault.encrypt(level_1_set)
         assert len(level_1_set_encrypted) == 3
@@ -55,6 +63,8 @@ class TestEvervault(unittest.TestCase):
     @requests_mock.Mocker()
     def test_encrypt_lists_of_various_types(self, mock_request):
         self.mock_fetch_cage_key(mock_request)
+        self.mock_metrics_endpoint(mock_request)
+
         level_1_list = ["a", True, 3]
         level_1_list_encrypted = self.evervault.encrypt(level_1_list)
         for item in level_1_list_encrypted:
@@ -72,6 +82,8 @@ class TestEvervault(unittest.TestCase):
     @requests_mock.Mocker()
     def test_encrypt_dicts(self, mock_request):
         self.mock_fetch_cage_key(mock_request)
+        self.mock_metrics_endpoint(mock_request)
+
         test_payload = {
             "name": "testname",
             "age": 20,
@@ -88,6 +100,7 @@ class TestEvervault(unittest.TestCase):
     @requests_mock.Mocker()
     def test_encrypt_with_unsupported_type_throws_exception(self, mock_request):
         self.mock_fetch_cage_key(mock_request)
+        self.mock_metrics_endpoint(mock_request)
 
         class MyTestClass:
             x = 5
@@ -135,6 +148,8 @@ class TestEvervault(unittest.TestCase):
     @requests_mock.Mocker()
     def test_encrypt_and_run(self, mock_request):
         self.mock_fetch_cage_key(mock_request)
+        self.mock_metrics_endpoint(mock_request)
+
         request = mock_request.post(
             "https://run.evervault.com/testing-cage",
             json={"result": "there was an attempt"},
@@ -157,7 +172,9 @@ class TestEvervault(unittest.TestCase):
                 "x-async": "true",
             },
         )
+        self.mock_metrics_endpoint(mock_request)
         self.mock_fetch_cage_key(mock_request)
+
         resp = self.evervault.encrypt_and_run(
             "testing-cage", {"name": "testing"}, {"async": True, "version": 2}
         )
@@ -198,6 +215,12 @@ class TestEvervault(unittest.TestCase):
         mock_request.get(
             "https://api.evervault.com/cages/key",
             json={"ecdhKey": self.public_key.decode("utf8")},
+        )
+
+    def mock_metrics_endpoint(self, mock_request):
+        mock_request.post(
+            "https://api.evervault.com/metrics/sdkEncryptions?sdk=python&numEncryptions=1",
+            text="OK",
         )
 
     def build_keys(self):


### PR DESCRIPTION
# Why

To better support our SDK development, we need to have some insight on how the SDKs are getting used.

# How

This PR adds a non-blocking metrics reporter (runs in a different thread). This will batch encrypt metric notifications and run periodically, and will only block if the application is stopping and there are some requests left to send.