### PR TITLE
Add a `CONTRIBUTING.md` and checklist to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,12 @@
 # Why
+
 Add a short description about this PR.
 Add links to issues, tech plans etc.
 
 # How
+
 Describe how you've approached the problem
+
+# Checklist
+
+- [ ] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,40 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/everva
 
 ## Getting Started
 
-- `poetry install`
-- `poetry run pytest`
-- `poetry run black .`
-- `poetry run flake8 --ignore=E501,W503,E722`
+To make life easier, this module features a code formatter/linter and also a commit formatter/linter, so that our
+releases will be compatible with [semantic release](https://semantic-release.gitbook.io/semantic-release/).
+
+We also use [poetry](https://python-poetry.org/) to make dependency management and general development easier. Once you have poetry installed, you can install the dependencies using
+
+```shell
+poetry install
+```
+
+From there, you are able to run python using
+
+```shell
+poetry run python you_file.py
+```
+
+## Testing and Code Formatting
+
+We use [black](https://github.com/psf/black) and [flake8](https://flake8.pycqa.org/en/latest/) for code formatting and linting. You can run them through poetry by running
+
+```shell
+poetry run black .
+poetry run flake8 --ignore=E501,W503,E722
+```
+
+You can also run the tests using [pytest](https://docs.pytest.org/en/6.2.x/) by running
+
+```shell
+poetry run pytest
+```
+
+All of these are run using a GitHub action on pull-requests, so please ensure that your code passes these tests before pushing, to save yourself some time.
+
+## Commit Formatting & Releases
+
+To maintain compatibility with [semantic versioning](https://semver.org/), we use a combination of commit formatting and [semantic release](https://github.com/semantic-release/semantic-release).
+
+We use the commit style specified in [conventional commits](https://www.conventionalcommits.org/). Please ensure that all commits meet this format so that releases can be generated correctly.


### PR DESCRIPTION
# Why

Some changes were made with respect to how development is done in this repository, to bring it more in line with the Node SDK. These changes needed to be documented.

# How

A `CONTRIBUTING.md` was added, along with a checklist for the conventional commits style (to make sure everything remains compatible with semantic-release).

# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
