### PR TITLE
feat: Add optional retries to requests for cert and cage operations

### DIFF
--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -8,6 +8,7 @@ __version__ = "0.3.0"
 ev_client = None
 _api_key = None
 request_timeout = 30
+_retry = False
 
 BASE_URL_DEFAULT = "https://api.evervault.com/"
 BASE_RUN_URL_DEFAULT = "https://run.evervault.com/"
@@ -15,9 +16,13 @@ RELAY_URL_DEFAULT = "https://relay.evervault.com:443"
 CA_HOST_DEFAULT = "https://ca.evervault.com"
 
 
-def init(api_key, intercept=True, ignore_domains=[]):
+def init(api_key, intercept=True, ignore_domains=[], retry=False):
     global _api_key
+    global _retry
+
     _api_key = api_key
+    _retry = retry
+
     if intercept:
         __client().relay(ignore_domains)
 
@@ -52,6 +57,7 @@ def __client():
             base_run_url=os.environ.get("EV_CAGE_RUN_URL", BASE_RUN_URL_DEFAULT),
             relay_url=os.environ.get("EV_TUNNEL_HOSTNAME", RELAY_URL_DEFAULT),
             ca_host=os.environ.get("EV_CERT_HOSTNAME", CA_HOST_DEFAULT),
+            retry=_retry,
         )
         return ev_client
     else:

--- a/evervault/client.py
+++ b/evervault/client.py
@@ -19,13 +19,14 @@ class Client(object):
         base_run_url="https://run.evervault.com/",
         relay_url="https://relay.evervault.com:443",
         ca_host="https://ca.evervault.com",
+        retry=False,
     ):
         self.api_key = api_key
         self.base_url = base_url
         self.base_run_url = base_run_url
         self.relay_url = relay_url
         self.ca_host = ca_host
-        self.request = Request(self.api_key, request_timeout)
+        self.request = Request(self.api_key, request_timeout, retry)
         self.crypto_client = CryptoClient(api_key)
 
     @property
@@ -68,7 +69,9 @@ class Client(object):
         while ca_content is None and i < 2:
             i += 1
             try:
-                ca_content = requests.get(client_self.ca_host).content
+                ca_content = client_self.request.make_request(
+                    "GET", client_self.ca_host, {}, _is_ca=True
+                ).content
             except:  # noqa: E722
                 pass
 

--- a/evervault/http/request.py
+++ b/evervault/http/request.py
@@ -2,25 +2,50 @@ from ..errors import error_handler
 import json
 import requests
 import certifi
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
+retry_strategy = Retry(
+    total=3,
+    status_forcelist=[429, 500, 502, 503, 504],
+    allowed_methods=["HEAD", "GET", "OPTIONS", "POST", "PUT"],
+    backoff_factor=1,
+)
+adapter = HTTPAdapter(max_retries=retry_strategy)
 
 
 class Request(object):
-    def __init__(self, api_key, timeout=30):
+    def __init__(self, api_key, timeout=30, retry=False):
         self.http_session = requests.Session()
         self.timeout = timeout
         self.api_key = api_key
+        self.retry = retry
 
-    def make_request(self, method, url, params=None, optional_headers={}):
+    def make_request(self, method, url, params=None, optional_headers={}, _is_ca=False):
+        """
+        Make a request.
+
+        Keyword arguments:
+        params -- The parameters of the request (default None)
+        optional_headers -- Optional headers for the request (default {})
+        _is_ca -- If the request is for a certificate don't parse the response body (default False)
+        """
         from evervault import __version__
 
         req_params = self.__build_headers(method, params, optional_headers, __version__)
 
         request_object = requests if self.http_session is None else self.http_session
+        if self.retry:
+            request_object.mount("https://", adapter)
+            request_object.mount("http://", adapter)
         resp = self.__execute_request(request_object, method, url, req_params)
-
-        parsed_body = self.__parse_body(resp)
-        error_handler.raise_errors_on_failure(resp, parsed_body)
-        return parsed_body
+        if _is_ca:
+            error_handler.raise_errors_on_failure(resp, resp.content)
+            return resp
+        else:
+            parsed_body = self.__parse_body(resp)
+            error_handler.raise_errors_on_failure(resp, parsed_body)
+            return parsed_body
 
     def __build_headers(self, method, params, optional_headers, version):
         req_params = {}


### PR DESCRIPTION
# Why

Allow users to optionally enable retries for fetching the Evervault root cert and cage operations.

# How

Added an optional `retry` parameter to the `init()` function. 
If retries are enabled, cage operations and cert fetching will retry up to 3 times. 

# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
