### PR TITLE
fix(actions): add access token to checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
       - name: Setup Python 3.9
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
# Why

Semantic release needs the access token passed to checkout: from [here](https://python-semantic-release.readthedocs.io/en/latest/automatic-releases/github-actions.html).

# How

- Add token

# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
