### PR TITLE
Adding new cage errors 408 and 422

### DIFF
--- a/evervault/errors/error_handler.py
+++ b/evervault/errors/error_handler.py
@@ -12,6 +12,10 @@ def raise_errors_on_failure(resp, body=None):
         raise errors.AuthenticationError("Unauthorized")
     elif resp.status_code == 403:
         raise errors.AuthenticationError("Forbidden")
+    elif resp.status_code == 408:
+        raise errors.TimeoutError("Request timed out")
+    elif resp.status_code == 422:
+        raise errors.DecryptionError("Unable to decrypt data")
     elif resp.status_code == 500:
         raise errors.ServerError("Server Error")
     elif resp.status_code == 502:

--- a/evervault/errors/evervault_errors.py
+++ b/evervault/errors/evervault_errors.py
@@ -21,6 +21,14 @@ class AuthenticationError(EvervaultError):
     pass
 
 
+class TimeoutError(EvervaultError):
+    pass
+
+
+class DecryptionError(EvervaultError):
+    pass
+
+
 class ServerError(EvervaultError):
     pass
 


### PR DESCRIPTION
# Why

New errors are being sent from the cage run api

# How

Added handling of new errors

# Checklist

- [X] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
