### PR TITLE
add error type for rejected IP address

### DIFF
--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -3,7 +3,7 @@ from .client import Client
 from .errors.evervault_errors import AuthenticationError
 import os
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"
 
 ev_client = None
 _api_key = None

--- a/evervault/errors/error_handler.py
+++ b/evervault/errors/error_handler.py
@@ -11,7 +11,10 @@ def raise_errors_on_failure(resp, body=None):
     elif resp.status_code == 401:
         raise errors.AuthenticationError("Unauthorized")
     elif resp.status_code == 403:
-        if "x-evervault-error-code" in resp.headers and resp.headers["x-evervault-error-code"] == "forbidden-ip-error":
+        if (
+            "x-evervault-error-code" in resp.headers
+            and resp.headers["x-evervault-error-code"] == "forbidden-ip-error"
+        ):
             raise errors.ForbiddenIPError("IP is not present in Cage whitelist")
         else:
             raise errors.AuthenticationError("Forbidden")

--- a/evervault/errors/error_handler.py
+++ b/evervault/errors/error_handler.py
@@ -11,7 +11,7 @@ def raise_errors_on_failure(resp, body=None):
     elif resp.status_code == 401:
         raise errors.AuthenticationError("Unauthorized")
     elif resp.status_code == 403:
-        if resp.headers["x-evervault-error-code"] == "forbidden-ip-error":
+        if "x-evervault-error-code" in resp.headers and resp.headers["x-evervault-error-code"] == "forbidden-ip-error":
             raise errors.ForbiddenIPError("IP is not present in Cage whitelist")
         else:
             raise errors.AuthenticationError("Forbidden")

--- a/evervault/errors/error_handler.py
+++ b/evervault/errors/error_handler.py
@@ -11,7 +11,10 @@ def raise_errors_on_failure(resp, body=None):
     elif resp.status_code == 401:
         raise errors.AuthenticationError("Unauthorized")
     elif resp.status_code == 403:
-        raise errors.AuthenticationError("Forbidden")
+        if resp.headers["x-evervault-error-code"] == "forbidden-ip-error":
+            raise errors.ForbiddenIPError("IP is not present in Cage whitelist")
+        else:
+            raise errors.AuthenticationError("Forbidden")
     elif resp.status_code == 408:
         raise errors.TimeoutError("Request timed out")
     elif resp.status_code == 422:

--- a/evervault/errors/evervault_errors.py
+++ b/evervault/errors/evervault_errors.py
@@ -68,5 +68,6 @@ class UnknownEncryptType(EvervaultError):
 class CertDownloadError(EvervaultError):
     pass
 
+
 class ForbiddenIPError(EvervaultError):
     pass

--- a/evervault/errors/evervault_errors.py
+++ b/evervault/errors/evervault_errors.py
@@ -67,3 +67,6 @@ class UnknownEncryptType(EvervaultError):
 
 class CertDownloadError(EvervaultError):
     pass
+
+class ForbiddenIPError(EvervaultError):
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evervault"
-version = "0.4.3"
+version = "0.4.4"
 description = "Everault SDK"
 authors = ["Evervault <engineering@evervault.com>"]
 license = "MIT"

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -1,4 +1,8 @@
-from evervault.errors.evervault_errors import UnknownEncryptType, ForbiddenIPError, AuthenticationError
+from evervault.errors.evervault_errors import (
+    UnknownEncryptType,
+    ForbiddenIPError,
+    AuthenticationError,
+)
 import unittest
 import requests_mock
 import base64
@@ -171,11 +175,15 @@ class TestEvervault(unittest.TestCase):
             json={"error": "An error occurred"},
             request_headers={"Api-Key": "testing"},
             headers={"x-evervault-error-code": "forbidden-ip-error"},
-            status_code=403
+            status_code=403,
         )
-        self.assertRaises(ForbiddenIPError, self.evervault.encrypt_and_run, "testing-cage", {"name": "testing"})
+        self.assertRaises(
+            ForbiddenIPError,
+            self.evervault.encrypt_and_run,
+            "testing-cage",
+            {"name": "testing"},
+        )
         assert request.called
-
 
     @requests_mock.Mocker()
     def test_encrypt_and_forbidden_run(self, mock_request):
@@ -187,9 +195,14 @@ class TestEvervault(unittest.TestCase):
             json={"error": "An error occurred"},
             request_headers={"Api-Key": "testing"},
             headers={},
-            status_code=403
+            status_code=403,
         )
-        self.assertRaises(AuthenticationError, self.evervault.encrypt_and_run, "testing-cage", {"name": "testing"})
+        self.assertRaises(
+            AuthenticationError,
+            self.evervault.encrypt_and_run,
+            "testing-cage",
+            {"name": "testing"},
+        )
         assert request.called
 
     @requests_mock.Mocker()


### PR DESCRIPTION
# Why

Adding support for the Python SDK to handle Forbidden IP address responses from the Cage run api

# How

Check the evervault error code from the Cage run response on a 403 response

# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
