### PR TITLE
Jhonny/ev 832 assure the sdk does not make a call

### DIFF
--- a/evervault/client.py
+++ b/evervault/client.py
@@ -60,16 +60,16 @@ class Client(object):
         self.cert.setup()
 
     def get(self, path, params={}):
-        return self.request_handler.get(path, params)
+        return self.request_handler.get(path, params, check_cert=True)
 
     def post(self, path, params, optional_headers, cage_run=False):
-        return self.request_handler.post(path, params, optional_headers, cage_run)
+        return self.request_handler.post(path, params, optional_headers, cage_run, check_cert=True)
 
     def put(self, path, params):
-        return self.request_handler.put(path, params)
+        return self.request_handler.put(path, params, check_cert=True)
 
     def delete(self, path, params):
-        return self.request_handler.delete(path, params)
+        return self.request_handler.delete(path, params, check_cert=True)
 
     def __build_cage_run_headers(self, options):
         if options is None:

--- a/evervault/client.py
+++ b/evervault/client.py
@@ -63,7 +63,9 @@ class Client(object):
         return self.request_handler.get(path, params, check_cert=True)
 
     def post(self, path, params, optional_headers, cage_run=False):
-        return self.request_handler.post(path, params, optional_headers, cage_run, check_cert=True)
+        return self.request_handler.post(
+            path, params, optional_headers, cage_run, check_cert=True
+        )
 
     def put(self, path, params):
         return self.request_handler.put(path, params, check_cert=True)

--- a/evervault/client.py
+++ b/evervault/client.py
@@ -24,6 +24,7 @@ class Client(object):
         self.base_run_url = base_run_url
         self.relay_url = relay_url
         self.ca_host = ca_host
+        self.assert_cert = False
         request = Request(self.api_key, request_timeout, retry)
         time_service = TimeService()
         self.cert = RequestIntercept(
@@ -58,20 +59,21 @@ class Client(object):
     def relay(self, ignore_domains=[]):
         self.cert.setup_domains(ignore_domains)
         self.cert.setup()
+        self.assert_cert = True
 
     def get(self, path, params={}):
-        return self.request_handler.get(path, params, check_cert=True)
+        return self.request_handler.get(path, params, check_cert=self.assert_cert)
 
     def post(self, path, params, optional_headers, cage_run=False):
         return self.request_handler.post(
-            path, params, optional_headers, cage_run, check_cert=True
+            path, params, optional_headers, cage_run, check_cert=self.assert_cert
         )
 
     def put(self, path, params):
-        return self.request_handler.put(path, params, check_cert=True)
+        return self.request_handler.put(path, params, check_cert=self.assert_cert)
 
     def delete(self, path, params):
-        return self.request_handler.delete(path, params, check_cert=True)
+        return self.request_handler.delete(path, params, check_cert=self.assert_cert)
 
     def __build_cage_run_headers(self, options):
         if options is None:

--- a/evervault/http/requesthandler.py
+++ b/evervault/http/requesthandler.py
@@ -5,28 +5,44 @@ class RequestHandler(object):
         self.base_run_url = base_run_url
         self.request = request
 
-    def get(self, path, params={}):
+    def get(self, path, params={}, check_cert=False):
         if self.cert.is_certificate_expired():
             self.cert.setup()
+        if check_cert:
+            self.__assert_certificate_available()
+
         return self.request.make_request("GET", self.__url(path), params)
 
-    def post(self, path, params, optional_headers, cage_run=False):
+    def post(self, path, params, optional_headers, cage_run=False, check_cert=False):
         if self.cert.is_certificate_expired():
             self.cert.setup()
+        if check_cert:
+            self.__assert_certificate_available()
+
         return self.request.make_request(
             "POST", self.__url(path, cage_run), params, optional_headers
         )
 
-    def put(self, path, params):
+    def put(self, path, params, check_cert=False):
         if self.cert.is_certificate_expired():
             self.cert.setup()
+        if check_cert:
+            self.__assert_certificate_available()
+
         return self.request.make_request("PUT", self.__url(path), params)
 
-    def delete(self, path, params):
+    def delete(self, path, params, check_cert=False):
         if self.cert.is_certificate_expired():
             self.cert.setup()
+        if check_cert:
+            self.__assert_certificate_available()
+
         return self.request.make_request("DELETE", self.__url(path), params)
 
     def __url(self, path, cage_run=False):
         base_url = self.base_run_url if cage_run else self.base_url
         return base_url + path
+
+    def __assert_certificate_available(self):
+        if self.request.http_session.cert is None:
+            raise Exception('Certificate not available')

--- a/evervault/http/requesthandler.py
+++ b/evervault/http/requesthandler.py
@@ -6,43 +6,33 @@ class RequestHandler(object):
         self.request = request
 
     def get(self, path, params={}, check_cert=False):
-        if self.cert.is_certificate_expired():
-            self.cert.setup()
         if check_cert:
-            self.__assert_certificate_available()
-
+            self.__validate_certificate()
         return self.request.make_request("GET", self.__url(path), params)
 
     def post(self, path, params, optional_headers, cage_run=False, check_cert=False):
-        if self.cert.is_certificate_expired():
-            self.cert.setup()
         if check_cert:
-            self.__assert_certificate_available()
-
+            self.__validate_certificate()
         return self.request.make_request(
             "POST", self.__url(path, cage_run), params, optional_headers
         )
 
     def put(self, path, params, check_cert=False):
-        if self.cert.is_certificate_expired():
-            self.cert.setup()
         if check_cert:
-            self.__assert_certificate_available()
-
+            self.__validate_certificate()
         return self.request.make_request("PUT", self.__url(path), params)
 
     def delete(self, path, params, check_cert=False):
-        if self.cert.is_certificate_expired():
-            self.cert.setup()
         if check_cert:
-            self.__assert_certificate_available()
-
+            self.__validate_certificate()
         return self.request.make_request("DELETE", self.__url(path), params)
 
     def __url(self, path, cage_run=False):
         base_url = self.base_run_url if cage_run else self.base_url
         return base_url + path
 
-    def __assert_certificate_available(self):
+    def __validate_certificate(self):
         if self.request.http_session.cert is None:
             raise Exception("Certificate not available")
+        if self.cert.is_certificate_expired():
+            self.cert.setup()

--- a/evervault/http/requesthandler.py
+++ b/evervault/http/requesthandler.py
@@ -45,4 +45,4 @@ class RequestHandler(object):
 
     def __assert_certificate_available(self):
         if self.request.http_session.cert is None:
-            raise Exception('Certificate not available')
+            raise Exception("Certificate not available")

--- a/tests/test_handling_requests.py
+++ b/tests/test_handling_requests.py
@@ -55,7 +55,9 @@ class TestHandlingRequests(unittest.TestCase):
 
     @patch("evervault.http.requestintercept.RequestIntercept")
     @patch("evervault.http.requesthandler.RequestHandler")
-    def test_if_outbound_set_get_needs_to_assert_certificate_presence(self, cert, request):
+    def test_if_outbound_set_get_needs_to_assert_certificate_presence(
+        self, cert, request
+    ):
         with self.assertRaises(Exception) as context:
             request_handler = RequestHandler(
                 request, "https://someaddress.io", "https://anotheraddress.io", cert
@@ -66,7 +68,9 @@ class TestHandlingRequests(unittest.TestCase):
 
     @patch("evervault.http.requestintercept.RequestIntercept")
     @patch("evervault.http.requesthandler.RequestHandler")
-    def test_if_outbound_set_post_needs_to_assert_certificate_presence(self, cert, request):
+    def test_if_outbound_set_post_needs_to_assert_certificate_presence(
+        self, cert, request
+    ):
         with self.assertRaises(Exception) as context:
             request_handler = RequestHandler(
                 request, "https://someaddress.io", "https://anotheraddress.io", cert
@@ -81,27 +85,35 @@ class TestHandlingRequests(unittest.TestCase):
                     "x-version-id": "2",
                     "x-async": "true",
                 },
-                check_cert=True
+                check_cert=True,
             )
 
     @patch("evervault.http.requestintercept.RequestIntercept")
     @patch("evervault.http.requesthandler.RequestHandler")
-    def test_if_outbound_set_put_needs_to_assert_certificate_presence(self, cert, request):
+    def test_if_outbound_set_put_needs_to_assert_certificate_presence(
+        self, cert, request
+    ):
         with self.assertRaises(Exception) as context:
             request_handler = RequestHandler(
                 request, "https://someaddress.io", "https://anotheraddress.io", cert
             )
             cert.is_certificate_expired.return_value = False
             request.http_session.cert = None
-            request_handler.put("https://anyaddress.io", {"status": "queued"}, check_cert=True)
+            request_handler.put(
+                "https://anyaddress.io", {"status": "queued"}, check_cert=True
+            )
 
     @patch("evervault.http.requestintercept.RequestIntercept")
     @patch("evervault.http.requesthandler.RequestHandler")
-    def test_if_outbound_set_delete_needs_to_assert_certificate_presence(self, cert, request):
+    def test_if_outbound_set_delete_needs_to_assert_certificate_presence(
+        self, cert, request
+    ):
         with self.assertRaises(Exception) as context:
             request_handler = RequestHandler(
                 request, "https://someaddress.io", "https://anotheraddress.io", cert
             )
             cert.is_certificate_expired.return_value = False
             request.http_session.cert = None
-            request_handler.delete("https://anyaddress.io", {"status": "queued"}, check_cert=True)
+            request_handler.delete(
+                "https://anyaddress.io", {"status": "queued"}, check_cert=True
+            )

--- a/tests/test_handling_requests.py
+++ b/tests/test_handling_requests.py
@@ -58,7 +58,7 @@ class TestHandlingRequests(unittest.TestCase):
     def test_if_outbound_set_get_needs_to_assert_certificate_presence(
         self, cert, request
     ):
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(Exception):
             request_handler = RequestHandler(
                 request, "https://someaddress.io", "https://anotheraddress.io", cert
             )
@@ -71,7 +71,7 @@ class TestHandlingRequests(unittest.TestCase):
     def test_if_outbound_set_post_needs_to_assert_certificate_presence(
         self, cert, request
     ):
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(Exception):
             request_handler = RequestHandler(
                 request, "https://someaddress.io", "https://anotheraddress.io", cert
             )
@@ -93,7 +93,7 @@ class TestHandlingRequests(unittest.TestCase):
     def test_if_outbound_set_put_needs_to_assert_certificate_presence(
         self, cert, request
     ):
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(Exception):
             request_handler = RequestHandler(
                 request, "https://someaddress.io", "https://anotheraddress.io", cert
             )
@@ -108,7 +108,7 @@ class TestHandlingRequests(unittest.TestCase):
     def test_if_outbound_set_delete_needs_to_assert_certificate_presence(
         self, cert, request
     ):
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(Exception):
             request_handler = RequestHandler(
                 request, "https://someaddress.io", "https://anotheraddress.io", cert
             )

--- a/tests/test_handling_requests.py
+++ b/tests/test_handling_requests.py
@@ -52,3 +52,56 @@ class TestHandlingRequests(unittest.TestCase):
         cert.is_certificate_expired.return_value = True
         request_handler.delete("https://anyaddress.io", {"status": "queued"})
         cert.setup.assert_called()
+
+    @patch("evervault.http.requestintercept.RequestIntercept")
+    @patch("evervault.http.requesthandler.RequestHandler")
+    def test_if_outbound_set_get_needs_to_assert_certificate_presence(self, cert, request):
+        with self.assertRaises(Exception) as context:
+            request_handler = RequestHandler(
+                request, "https://someaddress.io", "https://anotheraddress.io", cert
+            )
+            cert.is_certificate_expired.return_value = False
+            request.http_session.cert = None
+            request_handler.get("https://anyaddress.io", check_cert=True)
+
+    @patch("evervault.http.requestintercept.RequestIntercept")
+    @patch("evervault.http.requesthandler.RequestHandler")
+    def test_if_outbound_set_post_needs_to_assert_certificate_presence(self, cert, request):
+        with self.assertRaises(Exception) as context:
+            request_handler = RequestHandler(
+                request, "https://someaddress.io", "https://anotheraddress.io", cert
+            )
+            cert.is_certificate_expired.return_value = False
+            request.http_session.cert = None
+            request_handler.post(
+                "https://run.anyaddress.com/testing-cage",
+                {"status": "queued"},
+                {
+                    "Api-Key": "testing",
+                    "x-version-id": "2",
+                    "x-async": "true",
+                },
+                check_cert=True
+            )
+
+    @patch("evervault.http.requestintercept.RequestIntercept")
+    @patch("evervault.http.requesthandler.RequestHandler")
+    def test_if_outbound_set_put_needs_to_assert_certificate_presence(self, cert, request):
+        with self.assertRaises(Exception) as context:
+            request_handler = RequestHandler(
+                request, "https://someaddress.io", "https://anotheraddress.io", cert
+            )
+            cert.is_certificate_expired.return_value = False
+            request.http_session.cert = None
+            request_handler.put("https://anyaddress.io", {"status": "queued"}, check_cert=True)
+
+    @patch("evervault.http.requestintercept.RequestIntercept")
+    @patch("evervault.http.requesthandler.RequestHandler")
+    def test_if_outbound_set_delete_needs_to_assert_certificate_presence(self, cert, request):
+        with self.assertRaises(Exception) as context:
+            request_handler = RequestHandler(
+                request, "https://someaddress.io", "https://anotheraddress.io", cert
+            )
+            cert.is_certificate_expired.return_value = False
+            request.http_session.cert = None
+            request_handler.delete("https://anyaddress.io", {"status": "queued"}, check_cert=True)


### PR DESCRIPTION
# Why

Assert existence of certificate after calling relay in client.

# How

request handler now has a validation for certificate presence.
if relay was not called, then get, put, delete and post will not force certificate presence. 

