### PR TITLE
fix: remove code for cert check

### DIFF
--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -3,7 +3,7 @@ from .client import Client
 from .errors.evervault_errors import AuthenticationError, UnsupportedCurveError
 import os
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 
 ev_client = None
 _api_key = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evervault"
-version = "0.7.1"
+version = "0.7.2"
 description = "Everault SDK"
 authors = ["Evervault <engineering@evervault.com>"]
 license = "MIT"


### PR DESCRIPTION
# Why
Cert check code for lambda error is non functional
# How
Removed commits that introduced code.

# Checklist
- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
