### PR TITLE
Jhonny/ev 846 python sdk sometimes does not perform

### DIFF
--- a/evervault/client.py
+++ b/evervault/client.py
@@ -26,11 +26,11 @@ class Client(object):
         self.ca_host = ca_host
         request = Request(self.api_key, request_timeout, retry)
         time_service = TimeService()
-        self.cert = RequestIntercept(
+        request_intercept = RequestIntercept(
             request, ca_host, base_run_url, base_url, api_key, relay_url, time_service
         )
         self.request_handler = RequestHandler(
-            request, base_run_url, base_url, self.cert
+            request, base_run_url, base_url, request_intercept
         )
         self.crypto_client = CryptoClient(api_key, curve)
 
@@ -56,8 +56,7 @@ class Client(object):
         return CageList(cages, self).cages
 
     def relay(self, ignore_domains=[]):
-        self.cert.setup_domains(ignore_domains)
-        self.cert.setup()
+        self.request_handler.setup_certificate(ignore_domains)
 
     def get(self, path, params={}):
         return self.request_handler.get(path, params)

--- a/evervault/http/requesthandler.py
+++ b/evervault/http/requesthandler.py
@@ -1,31 +1,40 @@
 class RequestHandler(object):
-    def __init__(self, request, base_run_url, base_url, cert):
-        self.cert = cert
+    def __init__(self, request, base_run_url, base_url, request_intercept):
+        self.request_intercept = request_intercept
         self.base_url = base_url
         self.base_run_url = base_run_url
         self.request = request
+        self.requires_certificate = False
+
+    def setup_certificate(self, ignore_domains=[]):
+        self.requires_certificate = True
+        self.request_intercept.setup_domains(ignore_domains)
+        self.request_intercept.setup()
 
     def get(self, path, params={}):
-        if self.cert.is_certificate_expired():
-            self.cert.setup()
+        self.__validate_cert_if_needed()
         return self.request.make_request("GET", self.__url(path), params)
 
     def post(self, path, params, optional_headers, cage_run=False):
-        if self.cert.is_certificate_expired():
-            self.cert.setup()
+        self.__validate_cert_if_needed()
         return self.request.make_request(
             "POST", self.__url(path, cage_run), params, optional_headers
         )
 
     def put(self, path, params):
-        if self.cert.is_certificate_expired():
-            self.cert.setup()
+        self.__validate_cert_if_needed()
         return self.request.make_request("PUT", self.__url(path), params)
 
     def delete(self, path, params):
-        if self.cert.is_certificate_expired():
-            self.cert.setup()
+        self.__validate_cert_if_needed()
         return self.request.make_request("DELETE", self.__url(path), params)
+
+    def __validate_cert_if_needed(self):
+        if self.requires_certificate:
+            if self.request_intercept.is_certificate_expired():
+                self.request_intercept.setup()
+            if self.request_intercept.certificate_not_available():
+                raise Exception("Certificate not available")
 
     def __url(self, path, cage_run=False):
         base_url = self.base_run_url if cage_run else self.base_url

--- a/evervault/http/requestintercept.py
+++ b/evervault/http/requestintercept.py
@@ -12,14 +12,14 @@ from evervault.errors.evervault_errors import CertDownloadError
 
 class RequestIntercept(object):
     def __init__(
-            self,
-            request,
-            ca_host,
-            base_run_url,
-            base_url,
-            api_key,
-            relay_url,
-            datetime_service,
+        self,
+        request,
+        ca_host,
+        base_run_url,
+        base_url,
+        api_key,
+        relay_url,
+        datetime_service,
     ):
         self.datetime_service = datetime_service
         self.relay_url = relay_url
@@ -69,23 +69,23 @@ class RequestIntercept(object):
         requests.sessions.SessionRedirectMixin.rebuild_proxies = rebuild_proxies
 
         def new_req_func(
-                self,
-                method,
-                url,
-                params=None,
-                data=None,
-                headers={},
-                cookies=None,
-                files=None,
-                auth=None,
-                timeout=None,
-                allow_redirects=True,
-                proxies={},
-                hooks=None,
-                stream=None,
-                verify=None,
-                cert=None,
-                json=None,
+            self,
+            method,
+            url,
+            params=None,
+            data=None,
+            headers={},
+            cookies=None,
+            files=None,
+            auth=None,
+            timeout=None,
+            allow_redirects=True,
+            proxies={},
+            hooks=None,
+            stream=None,
+            verify=None,
+            cert=None,
+            json=None,
         ):
             if headers is None:
                 headers = {}
@@ -97,7 +97,7 @@ class RequestIntercept(object):
             try:
                 domain = urlparse(url).netloc
                 if domain in self.ignore_if_exact or domain.endswith(
-                        self.ignore_if_endswith
+                    self.ignore_if_endswith
                 ):
                     del headers["Proxy-Authorization"]
                     del proxies["https"]

--- a/evervault/http/requestintercept.py
+++ b/evervault/http/requestintercept.py
@@ -12,14 +12,14 @@ from evervault.errors.evervault_errors import CertDownloadError
 
 class RequestIntercept(object):
     def __init__(
-        self,
-        request,
-        ca_host,
-        base_run_url,
-        base_url,
-        api_key,
-        relay_url,
-        datetime_service,
+            self,
+            request,
+            ca_host,
+            base_run_url,
+            base_url,
+            api_key,
+            relay_url,
+            datetime_service,
     ):
         self.datetime_service = datetime_service
         self.relay_url = relay_url
@@ -34,12 +34,12 @@ class RequestIntercept(object):
         self.ignore_if_exact = []
         self.ignore_if_endswith = ()
 
+    def certificate_not_available(self):
+        return self.cert_path is None
+
     def is_certificate_expired(self):
-        if self.expire_date is not None:
-            now = self.datetime_service.get_datetime_now()
-            if now > self.expire_date or now < self.initial_date:
-                return True
-        return False
+        now = self.datetime_service.get_datetime_now()
+        return now > self.expire_date or now < self.initial_date
 
     def setup_domains(self, ignore_domains=[]):
         ignore_domains.append(urlparse(self.base_run_url).netloc)
@@ -69,23 +69,23 @@ class RequestIntercept(object):
         requests.sessions.SessionRedirectMixin.rebuild_proxies = rebuild_proxies
 
         def new_req_func(
-            self,
-            method,
-            url,
-            params=None,
-            data=None,
-            headers={},
-            cookies=None,
-            files=None,
-            auth=None,
-            timeout=None,
-            allow_redirects=True,
-            proxies={},
-            hooks=None,
-            stream=None,
-            verify=None,
-            cert=None,
-            json=None,
+                self,
+                method,
+                url,
+                params=None,
+                data=None,
+                headers={},
+                cookies=None,
+                files=None,
+                auth=None,
+                timeout=None,
+                allow_redirects=True,
+                proxies={},
+                hooks=None,
+                stream=None,
+                verify=None,
+                cert=None,
+                json=None,
         ):
             if headers is None:
                 headers = {}
@@ -97,7 +97,7 @@ class RequestIntercept(object):
             try:
                 domain = urlparse(url).netloc
                 if domain in self.ignore_if_exact or domain.endswith(
-                    self.ignore_if_endswith
+                        self.ignore_if_endswith
                 ):
                     del headers["Proxy-Authorization"]
                     del proxies["https"]

--- a/tests/test_handling_cert.py
+++ b/tests/test_handling_cert.py
@@ -60,32 +60,6 @@ class TestHandlingCerts(unittest.TestCase):
         assert cert.is_certificate_expired()
 
     @requests_mock.Mocker()
-    def test_not_available_cert_is_not_expired(self, mock_request):
-        mock_request.get("https://ca.evervault.com", text="")
-        base_url_default = "https://api.evervault.com/"
-        base_run_url_default = "https://run.evervault.com/"
-        ca_host_default = "https://ca.evervault.com"
-
-        api_key = "testing"
-
-        request = Request(api_key, 30, False)
-
-        time_service = TimeService()
-
-        cert = RequestIntercept(
-            request,
-            ca_host_default,
-            base_run_url_default,
-            base_url_default,
-            api_key,
-            api_key,
-            time_service,
-        )
-        cert.setup()
-
-        assert cert.is_certificate_expired() is False
-
-    @requests_mock.Mocker()
     def test_updated_cert_keeps_path_changes_timestamp(self, mock_request):
         mock_request.get(
             "https://ca.evervault.com",

--- a/tests/test_handling_requests.py
+++ b/tests/test_handling_requests.py
@@ -11,7 +11,9 @@ class TestHandlingRequests(unittest.TestCase):
         request_handler = RequestHandler(
             request, "https://someaddress.io", "https://anotheraddress.io", cert
         )
+        request_handler.setup_certificate([])
         cert.is_certificate_expired.return_value = True
+        cert.certificate_not_available.return_value = False
         request_handler.get("https://anyaddress.io")
         cert.setup.assert_called()
 
@@ -21,7 +23,9 @@ class TestHandlingRequests(unittest.TestCase):
         request_handler = RequestHandler(
             request, "https://someaddress.io", "https://anotheraddress.io", cert
         )
+        request_handler.setup_certificate([])
         cert.is_certificate_expired.return_value = True
+        cert.certificate_not_available.return_value = False
         request_handler.post(
             "https://run.anyaddress.com/testing-cage",
             {"status": "queued"},
@@ -39,7 +43,9 @@ class TestHandlingRequests(unittest.TestCase):
         request_handler = RequestHandler(
             request, "https://someaddress.io", "https://anotheraddress.io", cert
         )
+        request_handler.setup_certificate([])
         cert.is_certificate_expired.return_value = True
+        cert.certificate_not_available.return_value = False
         request_handler.put("https://anyaddress.io", {"status": "queued"})
         cert.setup.assert_called()
 
@@ -49,6 +55,8 @@ class TestHandlingRequests(unittest.TestCase):
         request_handler = RequestHandler(
             request, "https://someaddress.io", "https://anotheraddress.io", cert
         )
+        request_handler.setup_certificate([])
+        cert.certificate_not_available.return_value = False
         cert.is_certificate_expired.return_value = True
         request_handler.delete("https://anyaddress.io", {"status": "queued"})
         cert.setup.assert_called()


### PR DESCRIPTION
# Why
Make sure that we are using the certificate when performing http requests

# How

validating the certificate from the moment that we call relay()
when cert not present will throw.
Integration tests are passing locally for this implementation.