### PR TITLE
fix: empty proxies for each request

### DIFF
--- a/evervault/http/requestintercept.py
+++ b/evervault/http/requestintercept.py
@@ -119,8 +119,7 @@ class RequestIntercept(object):
         ):
             if headers is None:
                 headers = {}
-            if proxies is None:
-                proxies = {}
+            proxies = {}
 
             try:
                 domain = urlparse(url).netloc


### PR DESCRIPTION
# Why
Python SDK wasn't emptying the proxies list for each request, this led to some requests being sent through outbound that weren't meant to be sent through there.

This manifested in an issue when running the sdk inside of aws lambdas because the initial request to `ca.evervault.com` would be proxied through outbound if a proxied request occurred in any previous invocation.

# How

Reset the proxies list for each request.

# Checklist

- [ ] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
