### PR TITLE
Fix: Don't spawn thread in loop

### DIFF
--- a/evervault/http/repeated_timer.py
+++ b/evervault/http/repeated_timer.py
@@ -1,0 +1,26 @@
+from threading import Timer
+
+class RepeatedTimer(object):
+    def __init__(self, interval, function, *args, **kwargs):
+        self._timer     = None
+        self.interval   = interval
+        self.function   = function
+        self.args       = args
+        self.kwargs     = kwargs
+        self.is_running = False
+        self.start()
+
+    def _run(self):
+        self.is_running = False
+        self.start()
+        self.function(*self.args, **self.kwargs)
+
+    def start(self):
+        if not self.is_running:
+            self._timer = Timer(self.interval, self._run)
+            self._timer.start()
+            self.is_running = True
+
+    def stop(self):
+        self._timer.cancel()
+        self.is_running = False

--- a/evervault/http/repeated_timer.py
+++ b/evervault/http/repeated_timer.py
@@ -18,6 +18,7 @@ class RepeatedTimer(object):
     def start(self):
         if not self.is_running:
             self._timer = Timer(self.interval, self._run)
+            self._timer.daemon = True
             self._timer.start()
             self.is_running = True
 

--- a/evervault/http/repeated_timer.py
+++ b/evervault/http/repeated_timer.py
@@ -1,12 +1,13 @@
 from threading import Timer
 
+
 class RepeatedTimer(object):
     def __init__(self, interval, function, *args, **kwargs):
-        self._timer     = None
-        self.interval   = interval
-        self.function   = function
-        self.args       = args
-        self.kwargs     = kwargs
+        self._timer = None
+        self.interval = interval
+        self.function = function
+        self.args = args
+        self.kwargs = kwargs
         self.is_running = False
         self.start()
 

--- a/evervault/http/requestintercept.py
+++ b/evervault/http/requestintercept.py
@@ -8,7 +8,7 @@ import tempfile
 import threading
 import logging
 from evervault.errors.evervault_errors import CertDownloadError
-from . import repeated_timer
+from .repeated_timer import RepeatedTimer
 
 old_request_func = requests.Session.request
 logger = logging.getLogger(__name__)
@@ -96,7 +96,7 @@ class RequestIntercept(object):
 
     def _set_interval(self, func, sec):
         logger.debug(f"Starting Thread to poll evervault at {sec} second interval")
-        repeated_timer.RepeatedTimer(sec, func)
+        RepeatedTimer(sec, func)
 
     def setup(client_self):
         client_self.__get_cert()

--- a/evervault/http/requestintercept.py
+++ b/evervault/http/requestintercept.py
@@ -5,7 +5,6 @@ import requests
 import warnings
 import certifi
 import tempfile
-import threading
 import logging
 from evervault.errors.evervault_errors import CertDownloadError
 from .repeated_timer import RepeatedTimer


### PR DESCRIPTION
# Why
Thread is spawning in a loop calling the API recursively

# How
Use a Daemon timer which will check if it running before starting a new thread

# Checklist

- [X] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
