### PR TITLE
fix: Replace recursive timer call with RepeatedTimer class

### DIFF
--- a/evervault/http/repeated_timer.py
+++ b/evervault/http/repeated_timer.py
@@ -1,0 +1,29 @@
+from threading import Timer
+
+
+class RepeatedTimer(object):
+    def __init__(self, interval, function, *args, **kwargs):
+        self._timer = None
+        self.interval = interval
+        self.function = function
+        self.args = args
+        self.kwargs = kwargs
+        self.is_running = False
+        self.start()
+
+    def _run(self):
+        self.function(*self.args, **self.kwargs)
+
+    def running(self):
+        return self.is_running
+
+    def start(self):
+        if not self.is_running:
+            self._timer = Timer(self.interval, self._run)
+            self._timer.daemon = True
+            self._timer.start()
+            self.is_running = True
+
+    def stop(self):
+        self._timer.cancel()
+        self.is_running = False

--- a/evervault/http/requestintercept.py
+++ b/evervault/http/requestintercept.py
@@ -5,9 +5,9 @@ import requests
 import warnings
 import certifi
 import tempfile
-import threading
 import logging
 from evervault.errors.evervault_errors import CertDownloadError
+from .repeated_timer import RepeatedTimer
 
 old_request_func = requests.Session.request
 logger = logging.getLogger(__name__)
@@ -87,22 +87,15 @@ class RequestIntercept(object):
     def set_relay_outbound_config(self, debugRequests):
         self.debug_enabled = debugRequests
         self.__get_relay_outbound_config()
-        self.set_interval(self.__get_relay_outbound_config, 120)
+        self._set_interval(self.__get_relay_outbound_config, 120)
         always_ignore_domains = self.get_always_ignore_domains()
         self.should_proxy_domain = lambda host: is_ignore_domain(
             host, self.relay_outbound_destinations, always_ignore_domains
         )
 
-    def set_interval(self, func, sec):
+    def _set_interval(self, func, sec):
         logger.debug(f"Starting Thread to poll evervault at {sec} second interval")
-
-        def func_wrapper():
-            self.set_interval(func, sec)
-            func()
-
-        timer = threading.Timer(sec, func_wrapper)
-        timer.daemon = True
-        timer.start()
+        RepeatedTimer(sec, func)
 
     def setup(client_self):
         client_self.__get_cert()

--- a/tests/test_repeated_timer.py
+++ b/tests/test_repeated_timer.py
@@ -1,0 +1,26 @@
+from unittest import TestCase
+from unittest.mock import Mock
+import time
+
+from evervault.http.repeated_timer import RepeatedTimer
+
+
+class TestRepeatedTimer(TestCase):
+    def test_timer_is_running_on_init(self):
+        mock_object = Mock()
+        rt = RepeatedTimer(0.1, mock_object)
+        self.assertTrue(rt.running())
+
+    def test_timer_function_called_at_interval(self):
+        mock_object = Mock()
+        rt = RepeatedTimer(0.1, mock_object)
+        self.assertTrue(rt.running())
+        time.sleep(0.2)
+        mock_object.assert_called_once()
+
+    def test_timer_will_stop(self):
+        mock_object = Mock()
+        rt = RepeatedTimer(0.1, mock_object)
+        self.assertTrue(rt.running())
+        rt.stop()
+        self.assertFalse(rt.running())


### PR DESCRIPTION
# Why
Recursive call to create thread was creating multiple timers.

# How
- Create `RepeatedTimer` class which uses `Thread.Timer` to call for outbound relay config.

# Checklist

- [X] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
