### PR TITLE
Support aiohttp async requests in Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ evervault.create_run_token(function_name = str, data = dict)
 
 ### evervault.enable_outbound_relay()
 
-`evervault.enable_outbound_relay()` configures your application to proxy HTTP requests using Outbound Relay based on the configuration created in the Evervault dashboard. See [Outbound Relay](https://docs.evervault.com/concepts/outbound-relay/overview) to learn more.  
+`evervault.enable_outbound_relay()` configures your application to proxy HTTP requests using Outbound Relay based on the configuration created in the Evervault dashboard. See [Outbound Relay](https://docs.evervault.com/concepts/outbound-relay/overview) to learn more. 
+Asynchronous HTTP requests are supported with [aiohttp](https://docs.aiohttp.org/). Pass in a [aiohttp.ClientSession](https://docs.aiohttp.org/en/stable/client_reference.html) to enable them for that session. Note: Requires Python 3.11+
 
 ```python
 evervault.enable_outbound_relay([decryption_domains = Array, debug_requests = Boolean])
@@ -122,6 +123,8 @@ evervault.enable_outbound_relay([decryption_domains = Array, debug_requests = Bo
 | ------------------ | --------- | ------- | ---------------------------------------------------------------------------------------- |
 | decryption_domains | `Array`   | `None`  | Requests sent to any of the domains listed will be proxied through Outbound Relay. This will override the configuration created using the Evervault dashboard. |
 | debug_requests     | `Boolean` | `False` | Output request domains and whether they were sent through Outbound Relay.                |
+| client_session     | `[aiohttp.ClientSession](https://docs.aiohttp.org/en/stable/client_reference.html)` | `None`  | The [aiohttp](https://docs.aiohttp.org/) client session to enable outbound relay on. Requires Python >= 3.11.         |
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ evervault.enable_outbound_relay([decryption_domains = Array, debug_requests = Bo
 | ------------------ | --------- | ------- | ---------------------------------------------------------------------------------------- |
 | decryption_domains | `Array`   | `None`  | Requests sent to any of the domains listed will be proxied through Outbound Relay. This will override the configuration created using the Evervault dashboard. |
 | debug_requests     | `Boolean` | `False` | Output request domains and whether they were sent through Outbound Relay.                |
-| client_session     | `[aiohttp.ClientSession](https://docs.aiohttp.org/en/stable/client_reference.html)` | `None`  | The [aiohttp](https://docs.aiohttp.org/) client session to enable outbound relay on. Requires Python >= 3.11.         |
+| client_session     | [aiohttp.ClientSession](https://docs.aiohttp.org/en/stable/client_reference.html) | `None`  | The [aiohttp](https://docs.aiohttp.org/) client session to enable outbound relay on. Requires Python >= 3.11.         |
 
 
 ## Contributing

--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -2,6 +2,7 @@
 from .client import Client
 from .errors.evervault_errors import AuthenticationError, UnsupportedCurveError
 import os
+import sys
 from warnings import warn
 
 __version__ = "1.4.0"
@@ -98,14 +99,22 @@ def create_run_token(function_name, data):
     return __client().create_run_token(function_name, data)
 
 
-def enable_outbound_relay(decryption_domains=None, debug_requests=False):
+def enable_outbound_relay(decryption_domains=None, debug_requests=False, client_session=None):
+    if client_session is not None :
+        _warn_if_python_version_unsupported_for_async()
+        
     if decryption_domains is None:
-        __client().enable_outbound_relay(debug_requests, enable_outbound_relay=True)
+        __client().enable_outbound_relay(debug_requests, enable_outbound_relay=True, client_session=client_session)
     else:
         __client().enable_outbound_relay(
             debug_requests, decryption_domains=decryption_domains
         )
 
+def _warn_if_python_version_unsupported_for_async() :
+    if sys.version_info.minor < 11 :
+        warn(
+            "Using Outbound Relay with Asynchronous Python is only supported in Python >= 3.11"
+        )
 
 def __client():
     if not _api_key:

--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -99,22 +99,28 @@ def create_run_token(function_name, data):
     return __client().create_run_token(function_name, data)
 
 
-def enable_outbound_relay(decryption_domains=None, debug_requests=False, client_session=None):
-    if client_session is not None :
+def enable_outbound_relay(
+    decryption_domains=None, debug_requests=False, client_session=None
+):
+    if client_session is not None:
         _warn_if_python_version_unsupported_for_async()
-        
+
     if decryption_domains is None:
-        __client().enable_outbound_relay(debug_requests, enable_outbound_relay=True, client_session=client_session)
+        __client().enable_outbound_relay(
+            debug_requests, enable_outbound_relay=True, client_session=client_session
+        )
     else:
         __client().enable_outbound_relay(
             debug_requests, decryption_domains=decryption_domains
         )
 
-def _warn_if_python_version_unsupported_for_async() :
-    if sys.version_info.minor < 11 :
+
+def _warn_if_python_version_unsupported_for_async():
+    if sys.version_info.minor < 11:
         warn(
             "Using Outbound Relay with Asynchronous Python is only supported in Python >= 3.11"
         )
+
 
 def __client():
     if not _api_key:

--- a/evervault/client.py
+++ b/evervault/client.py
@@ -70,7 +70,7 @@ class Client(object):
         else:
             self.cert.setup_ignore_domains(ignore_domains, debug_requests)
         self.cert.setup()
-        if client_session :
+        if client_session:
             self.cert.setup_aiohttp(client_session)
 
     def create_run_token(self, cage_name, data):

--- a/evervault/client.py
+++ b/evervault/client.py
@@ -61,6 +61,7 @@ class Client(object):
         ignore_domains=[],
         decryption_domains=[],
         enable_outbound_relay=False,
+        client_session=None,
     ):
         if len(decryption_domains) > 0:
             self.cert.setup_decryption_domains(decryption_domains, debug_requests)
@@ -69,6 +70,8 @@ class Client(object):
         else:
             self.cert.setup_ignore_domains(ignore_domains, debug_requests)
         self.cert.setup()
+        if client_session :
+            self.cert.setup_aiohttp(client_session)
 
     def create_run_token(self, cage_name, data):
         return self.post(f"v2/functions/{cage_name}/run-token", data, {})

--- a/evervault/http/requestintercept.py
+++ b/evervault/http/requestintercept.py
@@ -112,7 +112,6 @@ class RequestIntercept(object):
 
         def new_req_func(method, str_or_url, **kwargs):
             domain = hostname_from_str_or_url(str_or_url)
-            print(domain)
             should_proxy = self.should_proxy_domain(domain)
 
             if "headers" not in kwargs:

--- a/evervault/http/requestintercept.py
+++ b/evervault/http/requestintercept.py
@@ -23,10 +23,11 @@ def is_ignore_domain(domain, decryption_domains, always_ignore_domains):
         for decryption_domain in decryption_domains
     )
 
-def hostname_from_str_or_url(str_or_url) :
-    if hasattr(str_or_url, 'host') :
+
+def hostname_from_str_or_url(str_or_url):
+    if hasattr(str_or_url, "host"):
         return str_or_url.host
-    
+
     return urlparse(str_or_url).netloc
 
 
@@ -106,16 +107,16 @@ class RequestIntercept(object):
         evervault_ssl_context = ssl.create_default_context(cafile=self.cert_path)
         api_key = self.api_key
         relay_url = self.relay_url
-        
+
         old_request = client_session._request
-        
-        def new_req_func(method, str_or_url, **kwargs) :
+
+        def new_req_func(method, str_or_url, **kwargs):
             domain = hostname_from_str_or_url(str_or_url)
             print(domain)
             should_proxy = self.should_proxy_domain(domain)
 
-            if not 'headers' in kwargs :
-                kwargs['headers'] = {}
+            if not "headers" in kwargs:
+                kwargs["headers"] = {}
 
             if self.debug_requests and not any(
                 map(
@@ -126,15 +127,15 @@ class RequestIntercept(object):
                 print(
                     f"Request to domain: {domain}, Outbound Proxy enabled: {should_proxy}"
                 )
-            if should_proxy :
-                kwargs['proxy'] = relay_url
-                kwargs['headers']['Proxy-Authorization'] = api_key
-                kwargs['ssl'] = evervault_ssl_context
-            else :
-                kwargs['ssl'] = default_ssl_context
+            if should_proxy:
+                kwargs["proxy"] = relay_url
+                kwargs["headers"]["Proxy-Authorization"] = api_key
+                kwargs["ssl"] = evervault_ssl_context
+            else:
+                kwargs["ssl"] = default_ssl_context
 
             return old_request(method, str_or_url, **kwargs)
-        
+
         client_session._request = new_req_func
 
     def setup(client_self):

--- a/evervault/http/requestintercept.py
+++ b/evervault/http/requestintercept.py
@@ -115,7 +115,7 @@ class RequestIntercept(object):
             print(domain)
             should_proxy = self.should_proxy_domain(domain)
 
-            if not "headers" in kwargs:
+            if "headers" not in kwargs:
                 kwargs["headers"] = {}
 
             if self.debug_requests and not any(


### PR DESCRIPTION
# Why

Python SDK currently doesn't support aiohttp async requests.

# How

Added an option to provide an aiohttp Client for the SDK to wrap when enabling outbound Relay.

# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
