### PR TITLE
fix!: update cryptography dependency to remove vuln

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/evervault/evervault-python"
 [tool.poetry.dependencies]
 python = "^3.6.2"
 requests = "^2.24.0"
-cryptography = "^3.4.8"
+cryptography = "^39.0.1"
 certifi = "*"
 pycryptodome = "^3.10.1"
 pyasn1 = "^0.4.8"


### PR DESCRIPTION
# Why

Current version of python's cryptography package has a [vulnerability](https://github.com/advisories/GHSA-w7pp-m8wf-vj6r). This vulnerability is not exposed through this package as we do not consume this API, but we are many versions behind latest so it is worth updating.

# How

- Bump cryptography dependency to latest (39.0.1)
- Mark as a Breaking Change due to reduced platform support from cryptography dependency.

# Notes

The following breaking changes have occurred in the cryptography package since 3.4.8:
- Support for OpenSSL 1.1.0 has been removed. Users on older version of OpenSSL will need to upgrade.
- Dropped support for LibreSSL < 3.5. The new minimum LibreSSL version is 3.5.0. Going forward our policy is to support versions of LibreSSL that are available in versions of OpenBSD that are still receiving security support.
- Removed the encode_point and from_encoded_point methods on EllipticCurvePublicNumbers, which had been deprecated for several years. public_bytes() and from_encoded_point() should be used instead.
- Support for using MD5 or SHA1 in CertificateBuilder, other X.509 builders, and PKCS7 has been removed.
- Dropped support for macOS 10.10 and 10.11, macOS users must upgrade to 10.12 or newer.
- Dropped support for LibreSSL 2.9.x and 3.0.x. The new minimum LibreSSL version is 3.1+.
- Removed signer and verifier methods from the public key and private key classes. These methods were originally deprecated in version 2.0, but had an extended deprecation timeline due to usage. Any remaining users should transition to sign and verify.
- Reverted the nonstandard formatting of email address fields as E in rfc4514_string() methods from version 35.0.
- The X.509 PEM parsers now require that the PEM string passed have PEM delimiters of the correct type. For example, parsing a private key PEM concatenated with a certificate PEM will no longer be accepted by the PEM certificate parser.
- The X.509 certificate parser no longer allows negative serial numbers. RFC 5280 has always prohibited these.
- Additional forms of invalid ASN.1 found during X.509 parsing will raise an error on initial parse rather than when the malformed field is accessed.

Most of these breaking changes should be irrelevant for this project, but consumers of the project should note:
- Support for OpenSSL 1.1.0 has been removed. Users on older version of OpenSSL will need to upgrade.
- Dropped support for LibreSSL < 3.5
- Dropped support for macOS 10.10 and 10.11, macOS users must upgrade to 10.12 or newer

# Checklist

- [X] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
