### PR TITLE
feat: allow non preapproved payloads for run tokens

### DIFF
--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -109,6 +109,7 @@ def cage_requests_session(cage_attestation_data={}):
 def create_run_token(function_name, data):
     if data is None:  # Allow non pre-approved payloads
         data = {}  # Convert to dictionary to keep encoding consistent
+
     return __client().create_run_token(function_name, data)
 
 

--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -107,6 +107,8 @@ def cage_requests_session(cage_attestation_data={}):
 
 
 def create_run_token(function_name, data):
+    if data is None:  # Allow non pre-approved payloads
+        data = {}  # Convert to dictionary to keep encoding consistent
     return __client().create_run_token(function_name, data)
 
 


### PR DESCRIPTION
# Why

Run tokens should be able to be created without pre-approved payloads

# How

Allow users to pass nothing for the `data` argument and convert to an empty dictionary to keep encoding consistent.

# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
