### PR TITLE
fix: allow encryption of bytearrays

### DIFF
--- a/evervault/crypto/client.py
+++ b/evervault/crypto/client.py
@@ -48,8 +48,10 @@ class Client(object):
         if self.shared_key is None or type(self.shared_key) != bytes:
             raise InvalidPublicKeyError("Provided EC compressed point is invalid")
 
-        if type(data) == bytes or type(data) == bytearray:
+        if type(data) == bytes:
             return self.__encrypt_file(data)
+        elif type(data) == bytearray:
+            return self.__encrypt_file(bytes(data))
         elif type(data) == dict or type(data) == list or type(data) == set:
             return self.__traverse_and_encrypt(data)
         elif self.__encryptable_data(data):

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -117,6 +117,20 @@ class TestEvervault(unittest.TestCase):
         assert encrypted_data[7:9] == bytes([55, 00])
 
     @requests_mock.Mocker()
+    def test_encrypt_files(self, mock_request):
+        self.mock_fetch_cage_key(mock_request)
+
+        test_payload = bytearray(10)
+        encrypted_data = self.evervault.encrypt(test_payload)
+        assert self.__is_evervault_file(encrypted_data)
+
+        # Check that curve is set correctly
+        assert encrypted_data[6:7] == b"\00"
+
+        # Check that offset to data is set correctly
+        assert encrypted_data[7:9] == bytes([55, 00])
+
+    @requests_mock.Mocker()
     def test_encrypt_with_unsupported_type_throws_exception(self, mock_request):
         self.mock_fetch_cage_key(mock_request)
 

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -117,7 +117,7 @@ class TestEvervault(unittest.TestCase):
         assert encrypted_data[7:9] == bytes([55, 00])
 
     @requests_mock.Mocker()
-    def test_encrypt_files(self, mock_request):
+    def test_encrypt_files_with_bytearray(self, mock_request):
         self.mock_fetch_cage_key(mock_request)
 
         test_payload = bytearray(10)


### PR DESCRIPTION
# Why

`bytearray`s were throwing an error on encryption

# How

Casting `bytearray`s to `bytes`

# Checklist

- [X] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
