### PR TITLE
feat: throw error on file size too large

### DIFF
--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -20,6 +20,7 @@ RELAY_URL_DEFAULT = "https://relay.evervault.com:443"
 CA_HOST_DEFAULT = "https://ca.evervault.com"
 CAGES_CA_HOST_DEFAULT = "https://cages-ca.evervault.com"
 CAGES_HOST_DEFAULT = "cages.evervault.com"
+MAX_FILE_SIZE_IN_MB_DEFAULT = 25
 
 SUPPORTED_CURVES = ["SECP256K1", "SECP256R1"]
 
@@ -142,6 +143,9 @@ def __client():
         raise UnsupportedCurveError(f"The {_curve} curve is not supported.")
     global ev_client
     if not ev_client:
+        max_file_size_in_mb = int(
+            os.environ.get("EV_MAX_FILE_SIZE_IN_MB", MAX_FILE_SIZE_IN_MB_DEFAULT)
+        )
         ev_client = Client(
             api_key=_api_key,
             request_timeout=request_timeout,
@@ -151,6 +155,7 @@ def __client():
             ca_host=os.environ.get("EV_CERT_HOSTNAME", CA_HOST_DEFAULT),
             retry=_retry,
             curve=_curve,
+            max_file_size_in_mb=max_file_size_in_mb,
         )
         return ev_client
     else:

--- a/evervault/client.py
+++ b/evervault/client.py
@@ -18,6 +18,7 @@ class Client(object):
         ca_host="https://ca.evervault.com",
         retry=False,
         curve="SECP256K1",
+        max_file_size_in_mb=25,
     ):
         self.api_key = api_key
         self.base_url = base_url
@@ -32,7 +33,7 @@ class Client(object):
         self.request_handler = RequestHandler(
             request, base_run_url, base_url, self.cert
         )
-        self.crypto_client = CryptoClient(api_key, curve)
+        self.crypto_client = CryptoClient(api_key, curve, max_file_size_in_mb)
 
     @property
     def _auth(self):

--- a/evervault/errors/evervault_errors.py
+++ b/evervault/errors/evervault_errors.py
@@ -75,3 +75,7 @@ class ForbiddenIPError(EvervaultError):
 
 class UnsupportedCurveError(EvervaultError):
     pass
+
+
+class ExceededMaxFileSizeError(EvervaultError):
+    pass


### PR DESCRIPTION
# Why

We do not support decryption of files >25MB so an error should be thrown if an attempt is made to encrypt a file larger than this size

# How

Added a max file size, compared the file size with this max

# Checklist

- [X] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
