### PR TITLE
Update Python SDK to add CRC32 checksum

### DIFF
--- a/evervault/crypto/client.py
+++ b/evervault/crypto/client.py
@@ -176,11 +176,7 @@ class Client(object):
 
     def __fetch_cage_key(self, fetch):
         if self.team_ecdh_key is None:
-            # resp = fetch.get("cages/key")
-            resp = {
-                "ecdhKey": "Aw9aPPL6XhmvEXkM6Lb0A/mXLVEb5Vs5WeuHTtvQBAi7",
-                "ecdhP256Key": "Al1/Mo85D7t/XvC3I+YYpJvP+OsSyxIbSrhtDhg1SClQ",
-            }
+            resp = fetch.get("cages/key")
             key_name = "ecdhKey" if self.curve == "SECP256K1" else "ecdhP256Key"
             self.decoded_team_cage_key = base64.b64decode(resp[key_name])
             self.team_ecdh_key = EllipticCurvePublicKey.from_encoded_point(

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -13,6 +13,7 @@ import evervault
 import os
 import requests
 import importlib
+import binascii
 
 
 class TestEvervault(unittest.TestCase):
@@ -111,10 +112,14 @@ class TestEvervault(unittest.TestCase):
         assert self.__is_evervault_file(encrypted_data)
 
         # Check that curve is set correctly
-        assert encrypted_data[6:7] == b"\00"
+        assert encrypted_data[6:7] == b"\02"
 
         # Check that offset to data is set correctly
         assert encrypted_data[7:9] == bytes([55, 00])
+
+        # Re-calculate the crc32 and ensure it matches
+        crc32 = binascii.crc32(encrypted_data[:-4])
+        assert encrypted_data[-4:] == crc32.to_bytes(4, byteorder="little")
 
     @requests_mock.Mocker()
     def test_encrypt_with_unsupported_type_throws_exception(self, mock_request):
@@ -371,10 +376,14 @@ class TestEvervault(unittest.TestCase):
         assert self.__is_evervault_file(encrypted_data)
 
         # Check that curve is set correctly
-        assert encrypted_data[6:7] == b"\01"
+        assert encrypted_data[6:7] == b"\03"
 
         # Check that offset to data is set correctly
         assert encrypted_data[7:9] == bytes([55, 00])
+
+        # Re-calculate the crc32 and ensure it matches
+        crc32 = binascii.crc32(encrypted_data[:-4])
+        assert encrypted_data[-4:] == crc32.to_bytes(4, byteorder="little")
 
     @requests_mock.Mocker()
     def test_p256_encrypt_with_unsupported_type_throws_exception(self, mock_request):


### PR DESCRIPTION
# Why
File encryption format now included a crc32 checksum

# How

Added the crc32 checksum to the end of the file computed with binascii in Python's standard library
Added tests to ensure it is added.

# Checklist

- [ ] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
