### PR TITLE
feat(cages attestation): allow users to pass in a list of sets of PCRs for attesting their Cages

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ evervault.enable_outbound_relay([decryption_domains = Array, debug_requests = Bo
 evervault.cage_requests_session([cage_attestation_data = dict])
 ```
 
-| Parameter             | Type   | Default | Description                                                                                                                                                                                          |
-| --------------------- | ------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| cage_attestation_data | `dict` | `None`  | Provide attestation measures to make assertions about the code running within your enclave. The `cage_attestation_data` dict is a mapping of cage names to their corresponding attestation measures. |
+| Parameter             | Type           | Default | Description                                                                                                                                                                                          |
+| --------------------- | -------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| cage_attestation_data | `dict`, `list` | `None`  | Provide attestation measures to make assertions about the code running within your enclave. The `cage_attestation_data` dict is a mapping of cage names to their corresponding attestation measures. A list of dicts can also be used passed, if you want to allow roll-over between different sets of PCRs |
 
 ## Contributing
 

--- a/evervault/cages_v2.py
+++ b/evervault/cages_v2.py
@@ -38,15 +38,23 @@ class CageHTTPAdapter(requests.adapters.HTTPAdapter):
         return conn
 
     def add_attestation_check_to_conn_validation(self, conn, cage_name):
-        expected_pcrs = evervault_attestation_bindings.PCRs.empty()
+        expected_pcrs = []
         if cage_name in self.attestation_data:
             given_pcrs = self.attestation_data[cage_name]
-            expected_pcrs = evervault_attestation_bindings.PCRs(
-                given_pcrs.get("pcr_0"),
-                given_pcrs.get("pcr_1"),
-                given_pcrs.get("pcr_2"),
-                given_pcrs.get("pcr_8"),
-            )
+            # if the user only supplied a single set of PCRs, convert it to a list
+            if not isinstance(given_pcrs, list):
+                given_pcrs = [given_pcrs]
+
+            for pcrs in given_pcrs:
+                expected_pcrs.append(
+                    evervault_attestation_bindings.PCRs(
+                        pcrs.get("pcr_0"),
+                        pcrs.get("pcr_1"),
+                        pcrs.get("pcr_2"),
+                        pcrs.get("pcr_8"),
+                    )
+                )
+
         original_validate_conn = (
             urllib3.connectionpool.HTTPSConnectionPool._validate_conn
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ cryptography = "^39.0.1"
 certifi = "*"
 pycryptodome = "^3.10.1"
 pyasn1 = "^0.4.8"
-evervault-attestation-bindings = "0.1.0a5"
+evervault-attestation-bindings = "0.2.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -132,7 +132,7 @@ class TestEvervault(unittest.TestCase):
         assert self.__is_evervault_file(encrypted_data)
 
         # Check that curve is set correctly
-        assert encrypted_data[6:7] == b"\00"
+        assert encrypted_data[6:7] == b"\02"
 
         # Check that offset to data is set correctly
         assert encrypted_data[7:9] == bytes([55, 00])
@@ -157,7 +157,7 @@ class TestEvervault(unittest.TestCase):
         assert self.__is_evervault_file(encrypted_data)
 
         # Check that curve is set correctly
-        assert encrypted_data[6:7] == b"\00"
+        assert encrypted_data[6:7] == b"\02"
 
         # Check that offset to data is set correctly
         assert encrypted_data[7:9] == bytes([55, 00])


### PR DESCRIPTION
# Why
User's may want to re-deploy their Cage with different PCRs, or signed with a different cert. This would allow users to attempt to attest their Cage using the old set of PCRs and the new set of PCRs. This would allow their client to keep making successful connections during a deployment.

# How
* Bump version of python attestation bindings used
* Coerce data given by user into a list, and pass that into the attestation bindings

# Checklist
- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
