### PR TITLE
feat!: Require App UUID when initialising the SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,17 @@ To make Evervault available for use in your app:
 ```python
 import evervault
 
-# Initialize the client with your team’s API key
-evervault.init("<YOUR_API_KEY>")
+# Initialize the client with your App’s API key and App's UUID
+evervault.init("<YOUR_API_KEY>", "<APP_ID>")
 
 # Encrypt your data
 encrypted = evervault.encrypt({ "name": "Claude" })
 
 # Process the encrypted data in a Function
 result = evervault.run("<YOUR_FUNCTION_NAME>", encrypted)
+
+# Decrypt data
+result = evervault.decrypt(encrypted)
 
 # Send the decrypted data to a third-party API
 evervault.enable_outbound_relay()
@@ -61,12 +64,13 @@ The Evervault Python SDK exposes five functions.
 `evervault.init()` initializes the SDK with your API key. Configurations for the interception of outbound requests may also be passed in this function.
 
 ```python
-evervault.init(api_key = str[, decryption_domains=[], retry = bool, curve = str])
+evervault.init(api_key = str, app_uuid = str[, decryption_domains=[], retry = bool, curve = str])
 ```
 
 | Parameter | Type  | Description                                                                                                                                                    |
 | --------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| api_key   | `str` | The API key of your Evervault Team                                                                                                                             |
+| api_key   | `str` | The API key of your Evervault App                                                                                                                             |
+| app_uuid   | `str` | The UUID of your Evervault App                                                                                                                             |
 | curve     | `str` | The elliptic curve used for cryptographic operations. See [Elliptic Curve Support](https://docs.evervault.com/reference/elliptic-curve-support) to learn more. |
 
 ### evervault.encrypt()
@@ -80,6 +84,18 @@ evervault.encrypt(data = dict | list | set | str | int | bool)
 | Parameter | Type                                        | Description          |
 | --------- | ------------------------------------------- | -------------------- |
 | data      | `dict`, `list`, `set`, `str`, `int`, `bool` | Data to be encrypted |
+
+### evervault.decrypt()
+
+`evervault.decerypt()` decrypts the data previously encrypted with the `encrypt()` function or through Relay.
+
+```python
+evervault.decrypt(data = dict | str | bytes | bytearray)
+```
+
+| Parameter | Type                                | Description          |
+| --------- | ----------------------------------- |--------------------- |
+| data      | `dict`, `str`, `bytes`, `bytearray` | Data to be decrypted |
 
 ### evervault.run()
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To make Evervault available for use in your app:
 import evervault
 
 # Initialize the client with your App’s API key and App's ID
-evervault.init("<YOUR_API_KEY>", "<APP_ID>")
+evervault.init("<APP_ID>", "<YOUR_API_KEY>")
 
 # Encrypt your data
 encrypted = evervault.encrypt({ "name": "Claude" })
@@ -64,12 +64,12 @@ The Evervault Python SDK exposes five functions.
 `evervault.init()` initializes the SDK with your API key. Configurations for the interception of outbound requests may also be passed in this function.
 
 ```python
-evervault.init(app_uuid = str, api_key = str[, decryption_domains=[], retry = bool, curve = str])
+evervault.init(app_id = str, api_key = str[, decryption_domains=[], retry = bool, curve = str])
 ```
 
 | Parameter | Type  | Description                                                                                                                                                    |
 | --------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| app_uuid   | `str` | The ID of your Evervault App |
+| app_id   | `str` | The ID of your Evervault App |
 | api_key   | `str` | The API key of your Evervault App |
 | curve     | `str` | The elliptic curve used for cryptographic operations. See [Elliptic Curve Support](https://docs.evervault.com/reference/elliptic-curve-support) to learn more. |
 
@@ -87,7 +87,8 @@ evervault.encrypt(data = dict | list | set | str | int | bool)
 
 ### evervault.decrypt()
 
-`evervault.decerypt()` decrypts the data previously encrypted with the `encrypt()` function or through Relay.
+`evervault.decrypt()` decrypts data previously encrypted with the `encrypt()` function or through Evervault's Relay (Evervault's encryption proxy).
+An API Key with the `decrypt` permission must be used to perform this operation.
 
 ```python
 evervault.decrypt(data = dict | str | bytes | bytearray)
@@ -100,6 +101,7 @@ evervault.decrypt(data = dict | str | bytes | bytearray)
 ### evervault.run()
 
 `evervault.run()` invokes a Function with a given payload.
+An API Key with the `run function` permission must be used to perform this operation.
 
 ```python
 evervault.run(function_name = str, data = dict[, options = dict])
@@ -121,6 +123,7 @@ evervault.run(function_name = str, data = dict[, options = dict])
 ### evervault.create_run_token()
 
 `evervault.create_run_token()` creates a single use, time bound token for invoking a function.
+An API Key with the `create Run Token` permission must be used to perform this operation.
 
 ```python
 evervault.create_run_token(function_name = str, data = dict)

--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ The Evervault Python SDK exposes five functions.
 `evervault.init()` initializes the SDK with your API key. Configurations for the interception of outbound requests may also be passed in this function.
 
 ```python
-evervault.init(api_key = str, app_uuid = str[, decryption_domains=[], retry = bool, curve = str])
+evervault.init(app_uuid = str, api_key = str[, decryption_domains=[], retry = bool, curve = str])
 ```
 
 | Parameter | Type  | Description                                                                                                                                                    |
 | --------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| api_key   | `str` | The API key of your Evervault App                                                                                                                             |
-| app_uuid   | `str` | The ID of your Evervault App                                                                                                                             |
+| app_uuid   | `str` | The ID of your Evervault App |
+| api_key   | `str` | The API key of your Evervault App |
 | curve     | `str` | The elliptic curve used for cryptographic operations. See [Elliptic Curve Support](https://docs.evervault.com/reference/elliptic-curve-support) to learn more. |
 
 ### evervault.encrypt()

--- a/README.md
+++ b/README.md
@@ -91,12 +91,12 @@ evervault.encrypt(data = dict | list | set | str | int | bool)
 An API Key with the `decrypt` permission must be used to perform this operation.
 
 ```python
-evervault.decrypt(data = dict | str | bytes | bytearray)
+evervault.decrypt(data =  str | dict | list | bytes | bytearray)
 ```
 
-| Parameter | Type                                | Description          |
-| --------- | ----------------------------------- |--------------------- |
-| data      | `dict`, `str`, `bytes`, `bytearray` | Data to be decrypted |
+| Parameter | Type                                        | Description          |
+| --------- | ------------------------------------------- |--------------------- |
+| data      | `str`, `dict`, `list`, `bytes`, `bytearray` | Data to be decrypted |
 
 ### evervault.run()
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To make Evervault available for use in your app:
 ```python
 import evervault
 
-# Initialize the client with your App’s API key and App's ID
+# Initialize the client with your App's ID and App’s API key
 evervault.init("<APP_ID>", "<YOUR_API_KEY>")
 
 # Encrypt your data

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To make Evervault available for use in your app:
 ```python
 import evervault
 
-# Initialize the client with your App’s API key and App's UUID
+# Initialize the client with your App’s API key and App's ID
 evervault.init("<YOUR_API_KEY>", "<APP_ID>")
 
 # Encrypt your data
@@ -70,7 +70,7 @@ evervault.init(api_key = str, app_uuid = str[, decryption_domains=[], retry = bo
 | Parameter | Type  | Description                                                                                                                                                    |
 | --------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | api_key   | `str` | The API key of your Evervault App                                                                                                                             |
-| app_uuid   | `str` | The UUID of your Evervault App                                                                                                                             |
+| app_uuid   | `str` | The ID of your Evervault App                                                                                                                             |
 | curve     | `str` | The elliptic curve used for cryptographic operations. See [Elliptic Curve Support](https://docs.evervault.com/reference/elliptic-curve-support) to learn more. |
 
 ### evervault.encrypt()

--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -9,8 +9,8 @@ from warnings import warn
 __version__ = "2.2.0"
 
 ev_client = None
-_api_key = None
 _app_uuid = None
+_api_key = None
 request_timeout = 30
 _retry = False
 _curve = None
@@ -32,8 +32,8 @@ class Curves(object):
 
 
 def init(
-    api_key,
     app_uuid,
+    api_key,
     decryption_domains=[],
     intercept=False,
     ignore_domains=[],
@@ -42,13 +42,13 @@ def init(
     debug_requests=False,
     enable_outbound_relay=False,
 ):
-    global _api_key
     global _app_uuid
+    global _api_key
     global _retry
     global _curve
 
-    _api_key = api_key
     _app_uuid = app_uuid
+    _api_key = api_key
     _retry = retry
     _curve = curve
 
@@ -143,13 +143,13 @@ def _warn_if_python_version_unsupported_for_async():
 
 
 def __client():
-    if not _api_key:
-        raise AuthenticationError(
-            "Your App's API Key must be entered using evervault.init('<API-KEY>', '<APP-UUID>')"
-        )
     if not _app_uuid:
         raise AuthenticationError(
             "Your App's App UUID must be entered using evervault.init('<API-KEY>', '<APP-UUID>')"
+        )
+    if not _api_key:
+        raise AuthenticationError(
+            "Your App's API Key must be entered using evervault.init('<API-KEY>', '<APP-UUID>')"
         )
     if _curve not in SUPPORTED_CURVES:
         raise UnsupportedCurveError(f"The {_curve} curve is not supported.")

--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -32,7 +32,7 @@ class Curves(object):
 
 
 def init(
-    app_uuid,
+    app_id,
     api_key,
     decryption_domains=[],
     intercept=False,
@@ -47,7 +47,7 @@ def init(
     global _retry
     global _curve
 
-    _app_uuid = app_uuid
+    _app_uuid = app_id
     _api_key = api_key
     _retry = retry
     _curve = curve
@@ -81,8 +81,8 @@ def run(function_name, data, options={"async": False, "version": None}):
     return __client().run(function_name, data, options)
 
 
-def decrypt(data, options={"async": False}):
-    return __client().decrypt(data, options)
+def decrypt(data):
+    return __client().decrypt(data)
 
 
 def encrypt(data):
@@ -145,11 +145,11 @@ def _warn_if_python_version_unsupported_for_async():
 def __client():
     if not _app_uuid:
         raise AuthenticationError(
-            "Your App's App UUID must be entered using evervault.init('<API-KEY>', '<APP-UUID>')"
+            "Your App's App UUID must be entered using evervault.init('<APP-ID>', '<API-KEY>')"
         )
     if not _api_key:
         raise AuthenticationError(
-            "Your App's API Key must be entered using evervault.init('<API-KEY>', '<APP-UUID>')"
+            "Your App's API Key must be entered using evervault.init('<APP-ID>', '<API-KEY>')"
         )
     if _curve not in SUPPORTED_CURVES:
         raise UnsupportedCurveError(f"The {_curve} curve is not supported.")

--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -10,6 +10,7 @@ __version__ = "2.2.0"
 
 ev_client = None
 _api_key = None
+_app_uuid = None
 request_timeout = 30
 _retry = False
 _curve = None
@@ -32,6 +33,7 @@ class Curves(object):
 
 def init(
     api_key,
+    app_uuid,
     decryption_domains=[],
     intercept=False,
     ignore_domains=[],
@@ -41,10 +43,12 @@ def init(
     enable_outbound_relay=False,
 ):
     global _api_key
+    global _app_uuid
     global _retry
     global _curve
 
     _api_key = api_key
+    _app_uuid = app_uuid
     _retry = retry
     _curve = curve
 
@@ -137,7 +141,11 @@ def _warn_if_python_version_unsupported_for_async():
 def __client():
     if not _api_key:
         raise AuthenticationError(
-            "Your Team's API Key must be entered using evervault.init('<API-KEY>')"
+            "Your App's API Key must be entered using evervault.init('<API-KEY>', '<APP-UUID>')"
+        )
+    if not _app_uuid:
+        raise AuthenticationError(
+            "Your App's App UUID must be entered using evervault.init('<API-KEY>', '<APP-UUID>')"
         )
     if _curve not in SUPPORTED_CURVES:
         raise UnsupportedCurveError(f"The {_curve} curve is not supported.")
@@ -148,6 +156,7 @@ def __client():
         )
         ev_client = Client(
             api_key=_api_key,
+            app_uuid=_app_uuid,
             request_timeout=request_timeout,
             base_url=os.environ.get("EV_API_URL", BASE_URL_DEFAULT),
             base_run_url=os.environ.get("EV_CAGE_RUN_URL", BASE_RUN_URL_DEFAULT),

--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -80,8 +80,10 @@ def init(
 def run(function_name, data, options={"async": False, "version": None}):
     return __client().run(function_name, data, options)
 
+
 def decrypt(data, options={"async": False}):
     return __client().decrypt(data, options)
+
 
 def encrypt(data):
     return __client().encrypt(data)

--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -80,6 +80,8 @@ def init(
 def run(function_name, data, options={"async": False, "version": None}):
     return __client().run(function_name, data, options)
 
+def decrypt(data, options={"async": False}):
+    return __client().decrypt(data, options)
 
 def encrypt(data):
     return __client().encrypt(data)

--- a/evervault/client.py
+++ b/evervault/client.py
@@ -49,7 +49,9 @@ class Client(object):
         if data is None:
             raise UndefinedDataError("Data is not defined")
         elif not isinstance(data, (str, dict, list, bytes)):
-            raise DecryptionError("data must be of type `str`, `dict`, `list` or `bytes`")
+            raise DecryptionError(
+                "data must be of type `str`, `dict`, `list` or `bytes`"
+            )
         headers = self.__build_decrypt_headers(type(data))
 
         if type(data) == bytes:

--- a/evervault/client.py
+++ b/evervault/client.py
@@ -5,10 +5,7 @@ from .crypto.client import Client as CryptoClient
 from .models.cage_list import CageList
 from .datatypes.map import ensure_is_integer
 from .services.timeservice import TimeService
-from .errors.evervault_errors import (
-    UndefinedDataError,
-    DecryptionError
-)
+from .errors.evervault_errors import UndefinedDataError, DecryptionError
 
 
 class Client(object):
@@ -110,7 +107,7 @@ class Client(object):
         headers["Content-Type"] = "application/json"
         if data_type == bytes:
             headers["Content-Type"] = "application/octet-stream"
-        
+
         if options is None:
             return headers
 

--- a/evervault/client.py
+++ b/evervault/client.py
@@ -11,8 +11,8 @@ from .errors.evervault_errors import UndefinedDataError, DecryptionError
 class Client(object):
     def __init__(
         self,
-        api_key=None,
         app_uuid=None,
+        api_key=None,
         request_timeout=30,
         base_url="https://api.evervault.com/",
         base_run_url="https://run.evervault.com/",
@@ -22,13 +22,13 @@ class Client(object):
         curve="SECP256K1",
         max_file_size_in_mb=25,
     ):
-        self.api_key = api_key
         self.app_uuid = app_uuid
+        self.api_key = api_key
         self.base_url = base_url
         self.base_run_url = base_run_url
         self.relay_url = relay_url
         self.ca_host = ca_host
-        request = Request(self.api_key, self.app_uuid, request_timeout, retry)
+        request = Request(self.app_uuid, self.api_key, request_timeout, retry)
         time_service = TimeService()
         self.cert = RequestIntercept(
             request, ca_host, base_run_url, base_url, api_key, relay_url, time_service

--- a/evervault/client.py
+++ b/evervault/client.py
@@ -11,6 +11,7 @@ class Client(object):
     def __init__(
         self,
         api_key=None,
+        app_uuid=None,
         request_timeout=30,
         base_url="https://api.evervault.com/",
         base_run_url="https://run.evervault.com/",
@@ -21,11 +22,12 @@ class Client(object):
         max_file_size_in_mb=25,
     ):
         self.api_key = api_key
+        self.app_uuid = app_uuid
         self.base_url = base_url
         self.base_run_url = base_run_url
         self.relay_url = relay_url
         self.ca_host = ca_host
-        request = Request(self.api_key, request_timeout, retry)
+        request = Request(self.api_key, self.app_uuid, request_timeout, retry)
         time_service = TimeService()
         self.cert = RequestIntercept(
             request, ca_host, base_run_url, base_url, api_key, relay_url, time_service

--- a/evervault/crypto/client.py
+++ b/evervault/crypto/client.py
@@ -141,7 +141,7 @@ class Client(object):
 
     def __coerce_type(self, data):
         if type(data) == bool:
-            return str(int(data))
+            return "true" if data else "false"
         elif type(data) == int or type(data) == float:
             return str(data)
         else:

--- a/evervault/http/request.py
+++ b/evervault/http/request.py
@@ -61,6 +61,7 @@ class Request(object):
             "Accept": "application/json",
             "Content-Type": "application/json",
             "Authorization": basic_auth_str,
+            "Api-Key": self.api_key,
         }
         headers.update(optional_headers)
         if method in ("POST", "PUT", "DELETE"):

--- a/evervault/http/request.py
+++ b/evervault/http/request.py
@@ -45,7 +45,8 @@ class Request(object):
             error_handler.raise_errors_on_failure(resp, resp.content)
             return resp
         else:
-            parsed_body = self.__parse_body(resp, req_params)
+            should_parse = req_params["headers"] and req_params["headers"]["Content-Type"] != "application/octet-stream"
+            parsed_body = self.__parse_body(resp, should_parse)
             error_handler.raise_errors_on_failure(resp, parsed_body)
             resp.parsed_body = parsed_body
             return resp
@@ -86,12 +87,12 @@ class Request(object):
             **req_params,
         )
 
-    def __parse_body(self, resp, req_params=None):
+    def __parse_body(self, resp, should_parse=True):
         if resp.content and resp.content.strip():
             try:
                 decoded_body = resp.content.decode(
                     resp.encoding or resp.apparent_encoding
                 )
-                return decoded_body if req_params and req_params["headers"]["Content-Type"] == "application/octet-stream" else json.loads(decoded_body)
+                return json.loads(decoded_body) if should_parse else decoded_body
             except ValueError:
                 error_handler.raise_errors_on_failure(resp)

--- a/evervault/http/request.py
+++ b/evervault/http/request.py
@@ -18,11 +18,11 @@ adapter = HTTPAdapter(max_retries=retry_strategy)
 class Request(object):
     decrypt_path = "/decrypt"
 
-    def __init__(self, api_key, app_uuid, timeout=30, retry=False):
+    def __init__(self, app_uuid, api_key, timeout=30, retry=False):
         self.http_session = requests.Session()
         self.timeout = timeout
-        self.api_key = api_key
         self.app_uuid = app_uuid
+        self.api_key = api_key
         self.retry = retry
 
     def make_request(self, method, url, params=None, optional_headers={}, _is_ca=False):
@@ -58,16 +58,12 @@ class Request(object):
 
     def __build_headers(self, method, params, url, optional_headers, version):
         req_params = {}
-        auth_value = f"{self.app_uuid}:{self.api_key}"
-        encoded_auth_value_bytes = base64.b64encode(auth_value.encode("ascii"))
-        basic_auth_str = f"Basic {encoded_auth_value_bytes.decode('utf-8')}"
+        
         headers = {
             "User-Agent": "evervault-python/" + version,
             "Accept-Encoding": "gzip, deflate",
             "Accept": "application/json",
             "Content-Type": "application/json",
-            "Authorization": basic_auth_str,
-            "Api-Key": self.api_key,
         }
 
         # Set correct auth header

--- a/evervault/http/request.py
+++ b/evervault/http/request.py
@@ -45,7 +45,10 @@ class Request(object):
             error_handler.raise_errors_on_failure(resp, resp.content)
             return resp
         else:
-            should_parse = req_params["headers"] and req_params["headers"]["Content-Type"] != "application/octet-stream"
+            should_parse = (
+                req_params["headers"]
+                and req_params["headers"]["Content-Type"] != "application/octet-stream"
+            )
             parsed_body = self.__parse_body(resp, should_parse)
             error_handler.raise_errors_on_failure(resp, parsed_body)
             resp.parsed_body = parsed_body

--- a/evervault/http/request.py
+++ b/evervault/http/request.py
@@ -36,7 +36,9 @@ class Request(object):
         """
         from evervault import __version__
 
-        req_params = self.__build_headers(method, params, url, optional_headers, __version__)
+        req_params = self.__build_headers(
+            method, params, url, optional_headers, __version__
+        )
 
         request_object = requests if self.http_session is None else self.http_session
         if self.retry:
@@ -58,7 +60,7 @@ class Request(object):
 
     def __build_headers(self, method, params, url, optional_headers, version):
         req_params = {}
-        
+
         headers = {
             "User-Agent": "evervault-python/" + version,
             "Accept-Encoding": "gzip, deflate",
@@ -74,7 +76,7 @@ class Request(object):
             headers["Authorization"] = basic_auth_str
         else:
             headers["Api-Key"] = self.api_key
-             
+
         headers.update(optional_headers)
         if method in ("POST", "PUT", "DELETE"):
             if type(params) == bytes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ homepage = "https://evervault.com"
 repository = "https://github.com/evervault/evervault-python"
 
 [tool.poetry.dependencies]
-python = "^3.7.0"
+python = "^3.9.0"
 requests = "^2.24.0"
 cryptography = "^41.0.0"
 certifi = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ pytest = "^6.2.5"
 pytest-socket = "^0.4.1"
 requests-mock = "^1.9.3"
 python-semantic-release = "^7.19.2"
-flake8 = "^3.9.2"
+flake8 = "^5.0.4"
 black = "^22.3.0"
 
 [pytest]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ homepage = "https://evervault.com"
 repository = "https://github.com/evervault/evervault-python"
 
 [tool.poetry.dependencies]
-python = "^3.9.0"
+python = "^3.7.0"
 requests = "^2.24.0"
 cryptography = "^41.0.0"
 certifi = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@ homepage = "https://evervault.com"
 repository = "https://github.com/evervault/evervault-python"
 
 [tool.poetry.dependencies]
-python = "^3.6.2"
+python = "^3.7.0"
 requests = "^2.24.0"
-cryptography = "^39.0.1"
+cryptography = "^41.0.0"
 certifi = "*"
 pycryptodome = "^3.10.1"
 pyasn1 = "^0.4.8"
@@ -30,7 +30,7 @@ testpath = "tests"
 
 [tool.black]
 line-length = 88
-target-version = ['py36', 'py37', 'py38', 'py39']
+target-version = ['py37', 'py38', 'py39']
 
 [tool.semantic_release]
 version_variable = [ "evervault/__init__.py:__version__" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ pytest-socket = "^0.4.1"
 requests-mock = "^1.9.3"
 python-semantic-release = "^7.19.2"
 flake8 = "^3.9.2"
-black = "^21.8b0"
+black = "^22.3.0"
 
 [pytest]
 testpath = "tests"

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -184,7 +184,6 @@ class TestEvervault(unittest.TestCase):
             json={"encrypted": "testString"},
             request_headers={
                 "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
-                "Api-Key": "testing",
                 "Content-Type": "application/json",
             },
         )
@@ -200,7 +199,6 @@ class TestEvervault(unittest.TestCase):
             json={"status": "queued"},
             request_headers={
                 "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
-                "Api-Key": "testing",
                 "Content-Type": "application/json",
                 "x-async": "true",
             },
@@ -219,7 +217,6 @@ class TestEvervault(unittest.TestCase):
             "https://run.evervault.com/testing-cage",
             json={"result": "there was an attempt"},
             request_headers={
-                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
                 "Api-Key": "testing",
             },
         )
@@ -234,7 +231,6 @@ class TestEvervault(unittest.TestCase):
             "https://run.evervault.com/testing-cage",
             json={"status": "queued"},
             request_headers={
-                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
                 "Api-Key": "testing",
                 "x-version-id": "2",
                 "x-async": "true",
@@ -257,7 +253,6 @@ class TestEvervault(unittest.TestCase):
             "https://run.evervault.com/testing-cage",
             json={"result": "there was an attempt"},
             request_headers={
-                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
                 "Api-Key": "testing",
             },
         )
@@ -275,7 +270,6 @@ class TestEvervault(unittest.TestCase):
             "https://run.evervault.com/testing-cage",
             json={"error": "An error occurred"},
             request_headers={
-                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
                 "Api-Key": "testing",
             },
             headers={"x-evervault-error-code": "forbidden-ip-error"},
@@ -297,7 +291,6 @@ class TestEvervault(unittest.TestCase):
             "https://run.evervault.com/testing-cage",
             json={"error": "An error occurred"},
             request_headers={
-                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
                 "Api-Key": "testing",
             },
             headers={},
@@ -317,7 +310,6 @@ class TestEvervault(unittest.TestCase):
             "https://run.evervault.com/testing-cage",
             json={"status": "queued"},
             request_headers={
-                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
                 "Api-Key": "testing",
                 "x-version-id": "2",
                 "x-async": "true",
@@ -564,7 +556,6 @@ class TestEvervault(unittest.TestCase):
             "https://run.evervault.com/testing-cage",
             json={"status": "queued"},
             request_headers={
-                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
                 "Api-Key": "testing",
                 "x-version-id": "2",
                 "x-async": "true",

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -185,7 +185,7 @@ class TestEvervault(unittest.TestCase):
             request_headers={
                 "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
                 "Api-Key": "testing",
-                "Content-Type": "application/json"
+                "Content-Type": "application/json",
             },
         )
         resp = self.evervault.decrypt({"encrypted": "ev:abc123"})
@@ -202,10 +202,12 @@ class TestEvervault(unittest.TestCase):
                 "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
                 "Api-Key": "testing",
                 "Content-Type": "application/json",
-                "x-async": "true"
+                "x-async": "true",
             },
         )
-        resp = self.evervault.decrypt({"encrypted": "ev:abc123"}, options={"async": True})
+        resp = self.evervault.decrypt(
+            {"encrypted": "ev:abc123"}, options={"async": True}
+        )
         assert request.called
         assert resp["status"] == "queued"
         assert request.last_request.json() == {"encrypted": "ev:abc123"}

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -182,7 +182,10 @@ class TestEvervault(unittest.TestCase):
         request = mock_request.post(
             "https://run.evervault.com/testing-cage",
             json={"result": "there was an attempt"},
-            request_headers={"Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw=="},
+            request_headers={
+                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
+                "Api-Key": "testing",
+            },
         )
         resp = self.evervault.run("testing-cage", {"name": "testing"})
         assert request.called
@@ -196,6 +199,7 @@ class TestEvervault(unittest.TestCase):
             json={"status": "queued"},
             request_headers={
                 "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
+                "Api-Key": "testing",
                 "x-version-id": "2",
                 "x-async": "true",
             },
@@ -216,7 +220,10 @@ class TestEvervault(unittest.TestCase):
         request = mock_request.post(
             "https://run.evervault.com/testing-cage",
             json={"result": "there was an attempt"},
-            request_headers={"Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw=="},
+            request_headers={
+                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
+                "Api-Key": "testing",
+            },
         )
         resp = self.evervault.encrypt_and_run("testing-cage", {"name": "testing"})
         assert request.called
@@ -231,7 +238,10 @@ class TestEvervault(unittest.TestCase):
         request = mock_request.post(
             "https://run.evervault.com/testing-cage",
             json={"error": "An error occurred"},
-            request_headers={"Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw=="},
+            request_headers={
+                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
+                "Api-Key": "testing",
+            },
             headers={"x-evervault-error-code": "forbidden-ip-error"},
             status_code=403,
         )
@@ -250,7 +260,10 @@ class TestEvervault(unittest.TestCase):
         request = mock_request.post(
             "https://run.evervault.com/testing-cage",
             json={"error": "An error occurred"},
-            request_headers={"Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw=="},
+            request_headers={
+                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
+                "Api-Key": "testing",
+            },
             headers={},
             status_code=403,
         )
@@ -269,6 +282,7 @@ class TestEvervault(unittest.TestCase):
             json={"status": "queued"},
             request_headers={
                 "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
+                "Api-Key": "testing",
                 "x-version-id": "2",
                 "x-async": "true",
             },
@@ -316,7 +330,10 @@ class TestEvervault(unittest.TestCase):
         request = mock_request.post(
             "https://api.evervault.com/v2/functions/testing-cage/run-token",
             json={"result": "there was an attempt"},
-            request_headers={"Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw=="},
+            request_headers={
+                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
+                "Api-Key": "testing",
+            },
         )
         resp = self.evervault.create_run_token("testing-cage", {"name": "testing"})
         assert request.called
@@ -450,7 +467,10 @@ class TestEvervault(unittest.TestCase):
         request = mock_request.post(
             "https://run.evervault.com/testing-cage",
             json={"result": "there was an attempt"},
-            request_headers={"Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw=="},
+            request_headers={
+                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
+                "Api-Key": "testing",
+            },
         )
         resp = self.evervault.run("testing-cage", {"name": "testing"})
         assert request.called
@@ -466,6 +486,7 @@ class TestEvervault(unittest.TestCase):
             json={"status": "queued"},
             request_headers={
                 "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
+                "Api-Key": "testing",
                 "x-version-id": "2",
                 "x-async": "true",
             },
@@ -488,7 +509,10 @@ class TestEvervault(unittest.TestCase):
         request = mock_request.post(
             "https://run.evervault.com/testing-cage",
             json={"result": "there was an attempt"},
-            request_headers={"Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw=="},
+            request_headers={
+                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
+                "Api-Key": "testing",
+            },
         )
         resp = self.evervault.encrypt_and_run("testing-cage", {"name": "testing"})
         assert request.called
@@ -505,6 +529,7 @@ class TestEvervault(unittest.TestCase):
             json={"status": "queued"},
             request_headers={
                 "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
+                "Api-Key": "testing",
                 "x-version-id": "2",
                 "x-async": "true",
             },

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -178,10 +178,10 @@ class TestEvervault(unittest.TestCase):
         self.assertRaises(UnknownEncryptType, self.evervault.encrypt, level_2_list)
 
     @requests_mock.Mocker()
-    def test_decrypt(self, mock_request):
+    def test_decrypt_dict(self, mock_request):
         request = mock_request.post(
             "https://api.evervault.com/decrypt",
-            json={"encrypted": "testString"},
+            json={"data": { "encrypted": "testString" }},
             request_headers={
                 "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
                 "Content-Type": "application/json",
@@ -190,26 +190,22 @@ class TestEvervault(unittest.TestCase):
         resp = self.evervault.decrypt({"encrypted": "ev:abc123"})
         assert request.called
         assert resp["encrypted"] == "testString"
-        assert request.last_request.json() == {"encrypted": "ev:abc123"}
+        assert request.last_request.json() == {"data": { "encrypted": "ev:abc123"}}
 
     @requests_mock.Mocker()
-    def test_decrypt_with_options(self, mock_request):
+    def test_decrypt_str(self, mock_request):
         request = mock_request.post(
             "https://api.evervault.com/decrypt",
-            json={"status": "queued"},
+            json={"data": "testString"},
             request_headers={
                 "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
                 "Content-Type": "application/json",
-                "x-async": "true",
             },
         )
-        resp = self.evervault.decrypt(
-            {"encrypted": "ev:abc123"}, options={"async": True}
-        )
+        resp = self.evervault.decrypt("ev:abc123")
         assert request.called
-        assert resp["status"] == "queued"
-        assert request.last_request.json() == {"encrypted": "ev:abc123"}
-        assert request.last_request.headers["x-async"] == "true"
+        assert resp == "testString"
+        assert request.last_request.json() == {"data": "ev:abc123"}
 
     @requests_mock.Mocker()
     def test_run(self, mock_request):

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -181,7 +181,7 @@ class TestEvervault(unittest.TestCase):
     def test_decrypt_dict(self, mock_request):
         request = mock_request.post(
             "https://api.evervault.com/decrypt",
-            json={"data": { "encrypted": "testString" }},
+            json={"data": {"encrypted": "testString"}},
             request_headers={
                 "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
                 "Content-Type": "application/json",
@@ -190,7 +190,7 @@ class TestEvervault(unittest.TestCase):
         resp = self.evervault.decrypt({"encrypted": "ev:abc123"})
         assert request.called
         assert resp["encrypted"] == "testString"
-        assert request.last_request.json() == {"data": { "encrypted": "ev:abc123"}}
+        assert request.last_request.json() == {"data": {"encrypted": "ev:abc123"}}
 
     @requests_mock.Mocker()
     def test_decrypt_str(self, mock_request):

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -24,7 +24,7 @@ class TestEvervault(unittest.TestCase):
         self.curve = curve
         importlib.reload(evervault)
         self.evervault = evervault
-        self.evervault.init("testing", "testAppUuid", curve=curve)
+        self.evervault.init("testAppUuid", "testing", curve=curve)
         self.public_key = self.build_keys()
 
     def tearDown(self):
@@ -332,7 +332,7 @@ class TestEvervault(unittest.TestCase):
         mock_request.get("https://ca.url.com", {})
 
         # Test default values
-        self.evervault.init("testing", "testAppUuid", intercept=True)
+        self.evervault.init("testAppUuid", "testing", intercept=True)
         assert self.evervault.ev_client.base_url == "https://api.evervault.com/"
         assert self.evervault.ev_client.base_run_url == "https://run.evervault.com/"
         assert self.evervault.ev_client.relay_url == "https://relay.evervault.com:443"
@@ -346,7 +346,7 @@ class TestEvervault(unittest.TestCase):
 
         # Force client to reinit
         self.evervault.ev_client = None
-        self.evervault.init("testing", "testAppUuid")
+        self.evervault.init("testAppUuid", "testing")
 
         assert self.evervault.ev_client.base_url == "https://custom.url.com"
         assert self.evervault.ev_client.base_run_url == "https://custom.run.url.com"
@@ -359,7 +359,6 @@ class TestEvervault(unittest.TestCase):
             "https://api.evervault.com/v2/functions/testing-cage/run-token",
             json={"result": "there was an attempt"},
             request_headers={
-                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
                 "Api-Key": "testing",
             },
         )
@@ -496,7 +495,6 @@ class TestEvervault(unittest.TestCase):
             "https://run.evervault.com/testing-cage",
             json={"result": "there was an attempt"},
             request_headers={
-                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
                 "Api-Key": "testing",
             },
         )
@@ -513,7 +511,6 @@ class TestEvervault(unittest.TestCase):
             "https://run.evervault.com/testing-cage",
             json={"status": "queued"},
             request_headers={
-                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
                 "Api-Key": "testing",
                 "x-version-id": "2",
                 "x-async": "true",
@@ -538,7 +535,6 @@ class TestEvervault(unittest.TestCase):
             "https://run.evervault.com/testing-cage",
             json={"result": "there was an attempt"},
             request_headers={
-                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
                 "Api-Key": "testing",
             },
         )
@@ -576,7 +572,7 @@ class TestEvervault(unittest.TestCase):
     def test_run_with_intercept_domain(self, mock_request):
         self.__mock_cert(mock_request)
 
-        evervault.init("testing", "testAppUuid", intercept=True)
+        evervault.init("testAppUuid", "testing", intercept=True)
 
         request = mock_request.get("https://test2.com/hello")
         requests.get("https://test2.com/hello")
@@ -589,7 +585,7 @@ class TestEvervault(unittest.TestCase):
         self.__mock_cert(mock_request)
 
         request = mock_request.get("https://run.evervault.com/hello")
-        evervault.init("testing", "testAppUuid", intercept=True)
+        evervault.init("testAppUuid", "testing", intercept=True)
 
         requests.get("https://run.evervault.com/hello")
 
@@ -603,7 +599,7 @@ class TestEvervault(unittest.TestCase):
     def test_run_with_decryption_domain_constructor(self, mock_request):
         self.__mock_cert(mock_request)
 
-        evervault.init("testing", "testAppUuid", decryption_domains=["test2.com"])
+        evervault.init("testAppUuid", "testing", decryption_domains=["test2.com"])
 
         request = mock_request.get("https://test2.com/hello")
         requests.get("https://test2.com/hello")
@@ -615,7 +611,7 @@ class TestEvervault(unittest.TestCase):
     def test_run_with_decryption_domain(self, mock_request):
         self.__mock_cert(mock_request)
 
-        evervault.init("testing", "testAppUuid")
+        evervault.init("testAppUuid", "testing")
         evervault.enable_outbound_relay(decryption_domains=["test2.com"])
 
         request = mock_request.get("https://test2.com/hello")
@@ -628,7 +624,7 @@ class TestEvervault(unittest.TestCase):
     def test_run_with_wildcard_decryption_domain(self, mock_request):
         self.__mock_cert(mock_request)
 
-        evervault.init("testing", "testAppUuid", decryption_domains=["*.test2.com"])
+        evervault.init("testAppUuid", "testing", decryption_domains=["*.test2.com"])
 
         request = mock_request.get("https://test.test2.com/hello")
         requests.get("https://test.test2.com/hello")
@@ -642,7 +638,7 @@ class TestEvervault(unittest.TestCase):
     ):
         self.__mock_cert(mock_request)
 
-        evervault.init("testing", "testAppUuid", decryption_domains=["test-other.com"])
+        evervault.init("testAppUuid", "testing", decryption_domains=["test-other.com"])
 
         request = mock_request.get("https://www.test2.com/hello")
         requests.get("https://www.test2.com/hello")
@@ -659,7 +655,7 @@ class TestEvervault(unittest.TestCase):
     ):
         self.__mock_cert(mock_request)
 
-        evervault.init("testing", "testAppUuid")
+        evervault.init("testAppUuid", "testing")
         evervault.enable_outbound_relay(decryption_domains=["test-other.com"])
 
         request = mock_request.get("https://www.test2.com/hello")
@@ -676,7 +672,7 @@ class TestEvervault(unittest.TestCase):
         self.__mock_cert(mock_request)
 
         request = mock_request.get("https://testing.com/hello")
-        evervault.init("testing", "testAppUuid", intercept=True)
+        evervault.init("testAppUuid", "testing", intercept=True)
 
         requests.get("https://testing.com/hello")
 
@@ -690,7 +686,7 @@ class TestEvervault(unittest.TestCase):
         self.__mock_relay_outbound_config(mock_request)
 
         request = mock_request.get("https://test-one.destinations.com/hello")
-        evervault.init("testing", "testAppUuid", enable_outbound_relay=True)
+        evervault.init("testAppUuid", "testing", enable_outbound_relay=True)
         requests.get("https://test-one.destinations.com/hello")
 
         assert request.last_request.headers["Proxy-Authorization"] == "testing"
@@ -702,7 +698,7 @@ class TestEvervault(unittest.TestCase):
         self.__mock_relay_outbound_config(mock_request)
 
         request = mock_request.get("https://test-one.destinations.com/hello")
-        evervault.init("testing", "testAppUuid")
+        evervault.init("testAppUuid", "testing")
         evervault.enable_outbound_relay()
         requests.get("https://test-one.destinations.com/hello")
 
@@ -766,7 +762,7 @@ class TestEvervault(unittest.TestCase):
         if self.evervault.ev_client.cert.relay_outbound_config is not None:
             self.evervault.ev_client.cert.relay_outbound_config.clear_cache()
         self.evervault.ev_client = None
-        self.evervault.init("testing", "testAppUuid")
+        self.evervault.init("testAppUuid", "testing")
         RelayOutboundConfig.clear_cache()
         RelayOutboundConfig.disable_polling()
 

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -208,6 +208,21 @@ class TestEvervault(unittest.TestCase):
         assert request.last_request.json() == {"data": "ev:abc123"}
 
     @requests_mock.Mocker()
+    def test_decrypt_bool(self, mock_request):
+        request = mock_request.post(
+            "https://api.evervault.com/decrypt",
+            json={"data": True},
+            request_headers={
+                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
+                "Content-Type": "application/json",
+            },
+        )
+        resp = self.evervault.decrypt("ev:abc123")
+        assert request.called
+        assert resp
+        assert request.last_request.json() == {"data": "ev:abc123"}
+
+    @requests_mock.Mocker()
     def test_run(self, mock_request):
         request = mock_request.post(
             "https://run.evervault.com/testing-cage",

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -178,6 +178,40 @@ class TestEvervault(unittest.TestCase):
         self.assertRaises(UnknownEncryptType, self.evervault.encrypt, level_2_list)
 
     @requests_mock.Mocker()
+    def test_decrypt(self, mock_request):
+        request = mock_request.post(
+            "https://api.evervault.com/decrypt",
+            json={"encrypted": "testString"},
+            request_headers={
+                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
+                "Api-Key": "testing",
+                "Content-Type": "application/json"
+            },
+        )
+        resp = self.evervault.decrypt({"encrypted": "ev:abc123"})
+        assert request.called
+        assert resp["encrypted"] == "testString"
+        assert request.last_request.json() == {"encrypted": "ev:abc123"}
+
+    @requests_mock.Mocker()
+    def test_decrypt_with_options(self, mock_request):
+        request = mock_request.post(
+            "https://api.evervault.com/decrypt",
+            json={"status": "queued"},
+            request_headers={
+                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
+                "Api-Key": "testing",
+                "Content-Type": "application/json",
+                "x-async": "true"
+            },
+        )
+        resp = self.evervault.decrypt({"encrypted": "ev:abc123"}, options={"async": True})
+        assert request.called
+        assert resp["status"] == "queued"
+        assert request.last_request.json() == {"encrypted": "ev:abc123"}
+        assert request.last_request.headers["x-async"] == "true"
+
+    @requests_mock.Mocker()
     def test_run(self, mock_request):
         request = mock_request.post(
             "https://run.evervault.com/testing-cage",

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -24,7 +24,7 @@ class TestEvervault(unittest.TestCase):
         self.curve = curve
         importlib.reload(evervault)
         self.evervault = evervault
-        self.evervault.init("testing", curve=curve)
+        self.evervault.init("testing", "testAppUuid", curve=curve)
         self.public_key = self.build_keys()
 
     def tearDown(self):
@@ -182,7 +182,7 @@ class TestEvervault(unittest.TestCase):
         request = mock_request.post(
             "https://run.evervault.com/testing-cage",
             json={"result": "there was an attempt"},
-            request_headers={"Api-Key": "testing"},
+            request_headers={"Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw=="},
         )
         resp = self.evervault.run("testing-cage", {"name": "testing"})
         assert request.called
@@ -195,7 +195,7 @@ class TestEvervault(unittest.TestCase):
             "https://run.evervault.com/testing-cage",
             json={"status": "queued"},
             request_headers={
-                "Api-Key": "testing",
+                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
                 "x-version-id": "2",
                 "x-async": "true",
             },
@@ -216,7 +216,7 @@ class TestEvervault(unittest.TestCase):
         request = mock_request.post(
             "https://run.evervault.com/testing-cage",
             json={"result": "there was an attempt"},
-            request_headers={"Api-Key": "testing"},
+            request_headers={"Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw=="},
         )
         resp = self.evervault.encrypt_and_run("testing-cage", {"name": "testing"})
         assert request.called
@@ -231,7 +231,7 @@ class TestEvervault(unittest.TestCase):
         request = mock_request.post(
             "https://run.evervault.com/testing-cage",
             json={"error": "An error occurred"},
-            request_headers={"Api-Key": "testing"},
+            request_headers={"Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw=="},
             headers={"x-evervault-error-code": "forbidden-ip-error"},
             status_code=403,
         )
@@ -250,7 +250,7 @@ class TestEvervault(unittest.TestCase):
         request = mock_request.post(
             "https://run.evervault.com/testing-cage",
             json={"error": "An error occurred"},
-            request_headers={"Api-Key": "testing"},
+            request_headers={"Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw=="},
             headers={},
             status_code=403,
         )
@@ -268,7 +268,7 @@ class TestEvervault(unittest.TestCase):
             "https://run.evervault.com/testing-cage",
             json={"status": "queued"},
             request_headers={
-                "Api-Key": "testing",
+                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
                 "x-version-id": "2",
                 "x-async": "true",
             },
@@ -290,7 +290,7 @@ class TestEvervault(unittest.TestCase):
         mock_request.get("https://ca.url.com", {})
 
         # Test default values
-        self.evervault.init("testing", intercept=True)
+        self.evervault.init("testing", "testAppUuid", intercept=True)
         assert self.evervault.ev_client.base_url == "https://api.evervault.com/"
         assert self.evervault.ev_client.base_run_url == "https://run.evervault.com/"
         assert self.evervault.ev_client.relay_url == "https://relay.evervault.com:443"
@@ -304,7 +304,7 @@ class TestEvervault(unittest.TestCase):
 
         # Force client to reinit
         self.evervault.ev_client = None
-        self.evervault.init("testing")
+        self.evervault.init("testing", "testAppUuid")
 
         assert self.evervault.ev_client.base_url == "https://custom.url.com"
         assert self.evervault.ev_client.base_run_url == "https://custom.run.url.com"
@@ -316,7 +316,7 @@ class TestEvervault(unittest.TestCase):
         request = mock_request.post(
             "https://api.evervault.com/v2/functions/testing-cage/run-token",
             json={"result": "there was an attempt"},
-            request_headers={"Api-Key": "testing"},
+            request_headers={"Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw=="},
         )
         resp = self.evervault.create_run_token("testing-cage", {"name": "testing"})
         assert request.called
@@ -450,7 +450,7 @@ class TestEvervault(unittest.TestCase):
         request = mock_request.post(
             "https://run.evervault.com/testing-cage",
             json={"result": "there was an attempt"},
-            request_headers={"Api-Key": "testing"},
+            request_headers={"Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw=="},
         )
         resp = self.evervault.run("testing-cage", {"name": "testing"})
         assert request.called
@@ -465,7 +465,7 @@ class TestEvervault(unittest.TestCase):
             "https://run.evervault.com/testing-cage",
             json={"status": "queued"},
             request_headers={
-                "Api-Key": "testing",
+                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
                 "x-version-id": "2",
                 "x-async": "true",
             },
@@ -488,7 +488,7 @@ class TestEvervault(unittest.TestCase):
         request = mock_request.post(
             "https://run.evervault.com/testing-cage",
             json={"result": "there was an attempt"},
-            request_headers={"Api-Key": "testing"},
+            request_headers={"Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw=="},
         )
         resp = self.evervault.encrypt_and_run("testing-cage", {"name": "testing"})
         assert request.called
@@ -504,7 +504,7 @@ class TestEvervault(unittest.TestCase):
             "https://run.evervault.com/testing-cage",
             json={"status": "queued"},
             request_headers={
-                "Api-Key": "testing",
+                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
                 "x-version-id": "2",
                 "x-async": "true",
             },
@@ -524,7 +524,7 @@ class TestEvervault(unittest.TestCase):
     def test_run_with_intercept_domain(self, mock_request):
         self.__mock_cert(mock_request)
 
-        evervault.init("testing", intercept=True)
+        evervault.init("testing", "testAppUuid", intercept=True)
 
         request = mock_request.get("https://test2.com/hello")
         requests.get("https://test2.com/hello")
@@ -537,7 +537,7 @@ class TestEvervault(unittest.TestCase):
         self.__mock_cert(mock_request)
 
         request = mock_request.get("https://run.evervault.com/hello")
-        evervault.init("testing", intercept=True)
+        evervault.init("testing", "testAppUuid", intercept=True)
 
         requests.get("https://run.evervault.com/hello")
 
@@ -551,7 +551,7 @@ class TestEvervault(unittest.TestCase):
     def test_run_with_decryption_domain_constructor(self, mock_request):
         self.__mock_cert(mock_request)
 
-        evervault.init("testing", decryption_domains=["test2.com"])
+        evervault.init("testing", "testAppUuid", decryption_domains=["test2.com"])
 
         request = mock_request.get("https://test2.com/hello")
         requests.get("https://test2.com/hello")
@@ -563,7 +563,7 @@ class TestEvervault(unittest.TestCase):
     def test_run_with_decryption_domain(self, mock_request):
         self.__mock_cert(mock_request)
 
-        evervault.init("testing")
+        evervault.init("testing", "testAppUuid")
         evervault.enable_outbound_relay(decryption_domains=["test2.com"])
 
         request = mock_request.get("https://test2.com/hello")
@@ -576,7 +576,7 @@ class TestEvervault(unittest.TestCase):
     def test_run_with_wildcard_decryption_domain(self, mock_request):
         self.__mock_cert(mock_request)
 
-        evervault.init("testing", decryption_domains=["*.test2.com"])
+        evervault.init("testing", "testAppUuid", decryption_domains=["*.test2.com"])
 
         request = mock_request.get("https://test.test2.com/hello")
         requests.get("https://test.test2.com/hello")
@@ -590,7 +590,7 @@ class TestEvervault(unittest.TestCase):
     ):
         self.__mock_cert(mock_request)
 
-        evervault.init("testing", decryption_domains=["test-other.com"])
+        evervault.init("testing", "testAppUuid", decryption_domains=["test-other.com"])
 
         request = mock_request.get("https://www.test2.com/hello")
         requests.get("https://www.test2.com/hello")
@@ -607,7 +607,7 @@ class TestEvervault(unittest.TestCase):
     ):
         self.__mock_cert(mock_request)
 
-        evervault.init("testing")
+        evervault.init("testing", "testAppUuid")
         evervault.enable_outbound_relay(decryption_domains=["test-other.com"])
 
         request = mock_request.get("https://www.test2.com/hello")
@@ -624,7 +624,7 @@ class TestEvervault(unittest.TestCase):
         self.__mock_cert(mock_request)
 
         request = mock_request.get("https://testing.com/hello")
-        evervault.init("testing", intercept=True)
+        evervault.init("testing", "testAppUuid", intercept=True)
 
         requests.get("https://testing.com/hello")
 
@@ -638,7 +638,7 @@ class TestEvervault(unittest.TestCase):
         self.__mock_relay_outbound_config(mock_request)
 
         request = mock_request.get("https://test-one.destinations.com/hello")
-        evervault.init("testing", enable_outbound_relay=True)
+        evervault.init("testing", "testAppUuid", enable_outbound_relay=True)
         requests.get("https://test-one.destinations.com/hello")
 
         assert request.last_request.headers["Proxy-Authorization"] == "testing"
@@ -650,7 +650,7 @@ class TestEvervault(unittest.TestCase):
         self.__mock_relay_outbound_config(mock_request)
 
         request = mock_request.get("https://test-one.destinations.com/hello")
-        evervault.init("testing")
+        evervault.init("testing", "testAppUuid")
         evervault.enable_outbound_relay()
         requests.get("https://test-one.destinations.com/hello")
 
@@ -714,7 +714,7 @@ class TestEvervault(unittest.TestCase):
         if self.evervault.ev_client.cert.relay_outbound_config is not None:
             self.evervault.ev_client.cert.relay_outbound_config.clear_cache()
         self.evervault.ev_client = None
-        self.evervault.init("testing")
+        self.evervault.init("testing", "testAppUuid")
         RelayOutboundConfig.clear_cache()
         RelayOutboundConfig.disable_polling()
 

--- a/tests/test_handling_cert.py
+++ b/tests/test_handling_cert.py
@@ -40,9 +40,10 @@ class TestHandlingCerts(unittest.TestCase):
         base_run_url_default = "https://run.evervault.com/"
         ca_host_default = "https://ca.evervault.com"
 
+        app_uuid = "testapp"
         api_key = "testing"
 
-        request = Request(api_key, 30, False)
+        request = Request(app_uuid, api_key, 30, False)
         time_service = TimeService()
 
         cert = RequestIntercept(
@@ -66,9 +67,10 @@ class TestHandlingCerts(unittest.TestCase):
         base_run_url_default = "https://run.evervault.com/"
         ca_host_default = "https://ca.evervault.com"
 
+        app_uuid = "testapp"
         api_key = "testing"
 
-        request = Request(api_key, 30, False)
+        request = Request(app_uuid, api_key, 30, False)
 
         time_service = TimeService()
 
@@ -116,9 +118,10 @@ class TestHandlingCerts(unittest.TestCase):
         base_run_url_default = "https://run.evervault.com/"
         ca_host_default = "https://ca.evervault.com"
 
+        app_uuid = "testapp"
         api_key = "testing"
 
-        request = Request(api_key, 30, False)
+        request = Request(app_uuid, api_key, 30, False)
 
         time_service = TimeService()
 
@@ -200,9 +203,10 @@ class TestHandlingCerts(unittest.TestCase):
         base_run_url_default = "https://run.evervault.com/"
         ca_host_default = "https://ca.evervault.com"
 
+        app_uuid = "testapp"
         api_key = "testing"
 
-        request = Request(api_key, 30, False)
+        request = Request(app_uuid, api_key, 30, False)
 
         time_service.get_datetime_now.return_value = 1171894763
 

--- a/tests/test_handling_requests.py
+++ b/tests/test_handling_requests.py
@@ -26,7 +26,7 @@ class TestHandlingRequests(unittest.TestCase):
             "https://run.anyaddress.com/testing-cage",
             {"status": "queued"},
             {
-                "Api-Key": "testing",
+                "Authorization": "Basic YXBwVXVpZDphcGlLZXk=",
                 "x-version-id": "2",
                 "x-async": "true",
             },

--- a/tests/test_outbound_relay_config.py
+++ b/tests/test_outbound_relay_config.py
@@ -9,7 +9,7 @@ from evervault.http.request import Request
 
 class TestOutboundRelayConfig(unittest.TestCase):
     def setUp(self):
-        self.request = Request("testing")
+        self.request = Request("testing", "testAppUuid")
         self.base_url = "https://api.evervault.com/"
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
BREAKING CHANGE: The UUID of the App is now required when initialising the SDK

# Why
Support is being added for the new `decrypt()` function. We will now require both the API key and the App UUID to perform authorization.

# How
- Include the `app_uuid` as a required argument to `init()`
- Include `decrypt()` function
- Update minimum Python version to `Python3.7`
- Update cryptography version to `^41.0.0`
- Update `flake8` and `black` dependency versions

# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked

BREAKING CHANGE: The UUID of the App is now required when initialising the SDK
