### PR TITLE
feat(tokens): adds support for creating decrypt tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,29 @@ evervault.run(function_name = str, data = dict[, options = dict])
 | async   | `Boolean` | `False` | Run your Function in async mode. Async Function runs will be queued for processing.      |
 | version | `Integer` | `None`  | Specify the version of your Function to run. By default, the latest version will be run. |
 
+### evervault.create_client_side_decrypt_token()
+
+`evervault.create_client_side_token()` creates a time-bound token for use in front end applications for decrypting data previously encrypted with Evervault.
+
+A payload of encrypted data must be provided to perform this operation. The payload ensures that the generated token will only be able to be used to decrypt this specific payload
+
+The expiry is the time at which the token will expire. The maximum expiry is 10 minutes in the future. If not provided, it defaults to 5 minutes in the future.
+
+```python
+from datetime import datetime, timedelta
+
+encrypted_data = evervault.encrypt("something sensitive")
+
+now = datetime.now()
+time_in_five_minutes = now + timedelta(minutes=5)
+token = evervault.create_client_side_decrypt_token(encrypted_data, time_in_five_minutes)
+```
+
+| Parameter     | Type                                        | Description                                                                                                |
+| ------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| data          | `str`, `dict`, `list`, `bytes`, `bytearray` | The payload ensures that the generated token will only be able to be used to decrypt this specific payload |
+| expiry        | `datetime`                                  | The time the token should expire. Max value is 10 minutes in the future, defaults to 5 minutes if `None`   |
+
 ### evervault.create_run_token()
 
 `evervault.create_run_token()` creates a single use, time bound token for invoking a function.

--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -84,8 +84,10 @@ def run(function_name, data, options={"async": False, "version": None}):
 def decrypt(data):
     return __client().decrypt(data)
 
+
 def create_client_side_decrypt_token(payload, expiry=None):
     return __client().create_token("decrypt:api", payload, expiry)
+
 
 def encrypt(data):
     return __client().encrypt(data)

--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -86,7 +86,7 @@ def decrypt(data):
 
 
 def create_client_side_decrypt_token(payload, expiry=None):
-    return __client().create_token("decrypt:api", payload, expiry)
+    return __client().create_token("api:decrypt", payload, expiry)
 
 
 def encrypt(data):

--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -84,6 +84,8 @@ def run(function_name, data, options={"async": False, "version": None}):
 def decrypt(data):
     return __client().decrypt(data)
 
+def create_client_side_decrypt_token(payload, expiry=None):
+    return __client().create_token("decrypt:api", payload, expiry)
 
 def encrypt(data):
     return __client().encrypt(data)

--- a/evervault/client.py
+++ b/evervault/client.py
@@ -64,12 +64,13 @@ class Client(object):
 
     def create_token(self, action, payload, expiry=None):
         if payload is None:
-            raise UndefinedDataError("Payload must be defined")
+            raise UndefinedDataError(
+                "Payload must be defined. It ensures that the generated token will only be able to be used to decrypt this specific payload"
+            )
         if expiry and not isinstance(expiry, datetime):
             raise UndefinedDataError("expiry must be an instance of `datetime`")
         if expiry and isinstance(expiry, datetime):
-            epoch = datetime.utcfromtimestamp(0)
-            expiry = (expiry - epoch).total_seconds() * 1000.0
+            expiry = int(expiry.timestamp() * 1000)
         data = {
             "payload": payload,
             "expiry": expiry,

--- a/evervault/client.py
+++ b/evervault/client.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from .http.requestintercept import RequestIntercept
 from .http.requesthandler import RequestHandler
 from .http.request import Request
@@ -60,6 +61,24 @@ class Client(object):
             payload = {"data": data}
             response = self.post("decrypt", payload, headers, False)
             return response["data"]
+
+    def create_token(self, action, payload, expiry=None):
+        if payload is None:
+            raise UndefinedDataError("Payload must be defined")
+        if expiry and not isinstance(expiry, datetime):
+            raise UndefinedDataError("expiry must be an instance of `datetime`")
+        if expiry and isinstance(expiry, datetime):
+            epoch = datetime.utcfromtimestamp(0)
+            expiry = (expiry - epoch).total_seconds() * 1000.0
+        data = {
+            "payload": payload,
+            "expiry": expiry,
+            "action": action,
+        }
+        headers = {
+            "Content-Type": "application/json",
+        }
+        return self.post("client-side-tokens", data, headers, False)
 
     def run(self, cage_name, data, options={"async": False, "version": None}):
         optional_headers = self.__build_cage_run_headers(options)

--- a/evervault/http/request.py
+++ b/evervault/http/request.py
@@ -16,7 +16,7 @@ adapter = HTTPAdapter(max_retries=retry_strategy)
 
 
 class Request(object):
-    decrypt_path = "/decrypt"
+    auth_header_paths = ["/decrypt", "/client-side-tokens"]
 
     def __init__(self, app_uuid, api_key, timeout=30, retry=False):
         self.http_session = requests.Session()
@@ -69,7 +69,7 @@ class Request(object):
         }
 
         # Set correct auth header
-        if Request.decrypt_path in url:
+        if any(map(url.__contains__, Request.auth_header_paths)):
             auth_value = f"{self.app_uuid}:{self.api_key}"
             encoded_auth_value_bytes = base64.b64encode(auth_value.encode("ascii"))
             basic_auth_str = f"Basic {encoded_auth_value_bytes.decode('utf-8')}"

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -211,9 +211,7 @@ class TestEvervault(unittest.TestCase):
             },
         )
         now = datetime.datetime.now()
-        expected_datetime_in_request = (
-            now - datetime.datetime.utcfromtimestamp(0)
-        ).total_seconds() * 1000.0
+        expected_datetime_in_request = int(now.timestamp() * 1000)
         resp = self.evervault.create_client_side_decrypt_token(
             {"data": "ev:abc123"}, now
         )

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -197,7 +197,7 @@ class TestEvervault(unittest.TestCase):
         assert request.last_request.json() == {
             "payload": {"data": "ev:abc123"},
             "expiry": None,
-            "action": "decrypt:api",
+            "action": "api:decrypt",
         }
 
     @requests_mock.Mocker()
@@ -222,7 +222,7 @@ class TestEvervault(unittest.TestCase):
         assert request.last_request.json() == {
             "payload": {"data": "ev:abc123"},
             "expiry": expected_datetime_in_request,
-            "action": "decrypt:api",
+            "action": "api:decrypt",
         }
 
     @requests_mock.Mocker()

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -18,6 +18,7 @@ import importlib
 import binascii
 import datetime
 
+
 class TestEvervault(unittest.TestCase):
     CURVES = {"SECP256K1": ec.SECP256K1, "SECP256R1": ec.SECP256R1}
 
@@ -182,33 +183,47 @@ class TestEvervault(unittest.TestCase):
     def test_create_decrypt_token_without_expiry(self, mock_request):
         request = mock_request.post(
             "https://api.evervault.com/client-side-tokens",
-            json={ "token": "token123", "expiry": 1234567890 },
+            json={"token": "token123", "expiry": 1234567890},
             request_headers={
                 "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
                 "Content-Type": "application/json",
             },
         )
-        resp = self.evervault.create_client_side_decrypt_token({"data": "ev:abc123"}, None)
+        resp = self.evervault.create_client_side_decrypt_token(
+            {"data": "ev:abc123"}, None
+        )
         assert request.called
-        assert resp == { "token": "token123", "expiry": 1234567890 }
-        assert request.last_request.json() == {"payload": {"data": "ev:abc123"}, "expiry": None, "action": "decrypt:api" }
+        assert resp == {"token": "token123", "expiry": 1234567890}
+        assert request.last_request.json() == {
+            "payload": {"data": "ev:abc123"},
+            "expiry": None,
+            "action": "decrypt:api",
+        }
 
     @requests_mock.Mocker()
     def test_create_decrypt_token_with_expiry(self, mock_request):
         request = mock_request.post(
             "https://api.evervault.com/client-side-tokens",
-            json={ "token": "token123", "expiry": 1234567890 },
+            json={"token": "token123", "expiry": 1234567890},
             request_headers={
                 "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
                 "Content-Type": "application/json",
             },
         )
         now = datetime.datetime.now()
-        expected_datetime_in_request = (now - datetime.datetime.utcfromtimestamp(0)).total_seconds() * 1000.0
-        resp = self.evervault.create_client_side_decrypt_token({"data": "ev:abc123"}, now)
+        expected_datetime_in_request = (
+            now - datetime.datetime.utcfromtimestamp(0)
+        ).total_seconds() * 1000.0
+        resp = self.evervault.create_client_side_decrypt_token(
+            {"data": "ev:abc123"}, now
+        )
         assert request.called
-        assert resp == { "token": "token123", "expiry": 1234567890 }
-        assert request.last_request.json() == {"payload": {"data": "ev:abc123"}, "expiry": expected_datetime_in_request, "action": "decrypt:api" }
+        assert resp == {"token": "token123", "expiry": 1234567890}
+        assert request.last_request.json() == {
+            "payload": {"data": "ev:abc123"},
+            "expiry": expected_datetime_in_request,
+            "action": "decrypt:api",
+        }
 
     @requests_mock.Mocker()
     def test_create_decrypt_token_without_payload_throws(self, mock_request):
@@ -216,7 +231,7 @@ class TestEvervault(unittest.TestCase):
             UndefinedDataError,
             self.evervault.create_client_side_decrypt_token,
             None,
-            None
+            None,
         )
 
     @requests_mock.Mocker()

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -3,6 +3,7 @@ from evervault.errors.evervault_errors import (
     ForbiddenIPError,
     AuthenticationError,
     ExceededMaxFileSizeError,
+    UndefinedDataError,
 )
 import unittest
 from evervault.http.outboundrelayconfig import RelayOutboundConfig
@@ -15,7 +16,7 @@ import os
 import requests
 import importlib
 import binascii
-
+import datetime
 
 class TestEvervault(unittest.TestCase):
     CURVES = {"SECP256K1": ec.SECP256K1, "SECP256R1": ec.SECP256R1}
@@ -176,6 +177,47 @@ class TestEvervault(unittest.TestCase):
         self.assertRaises(UnknownEncryptType, self.evervault.encrypt, test_instance)
         self.assertRaises(UnknownEncryptType, self.evervault.encrypt, level_1_list)
         self.assertRaises(UnknownEncryptType, self.evervault.encrypt, level_2_list)
+
+    @requests_mock.Mocker()
+    def test_create_decrypt_token_without_expiry(self, mock_request):
+        request = mock_request.post(
+            "https://api.evervault.com/client-side-tokens",
+            json={ "token": "token123", "expiry": 1234567890 },
+            request_headers={
+                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
+                "Content-Type": "application/json",
+            },
+        )
+        resp = self.evervault.create_client_side_decrypt_token({"data": "ev:abc123"}, None)
+        assert request.called
+        assert resp == { "token": "token123", "expiry": 1234567890 }
+        assert request.last_request.json() == {"payload": {"data": "ev:abc123"}, "expiry": None, "action": "decrypt:api" }
+
+    @requests_mock.Mocker()
+    def test_create_decrypt_token_with_expiry(self, mock_request):
+        request = mock_request.post(
+            "https://api.evervault.com/client-side-tokens",
+            json={ "token": "token123", "expiry": 1234567890 },
+            request_headers={
+                "Authorization": "Basic dGVzdEFwcFV1aWQ6dGVzdGluZw==",
+                "Content-Type": "application/json",
+            },
+        )
+        now = datetime.datetime.now()
+        expected_datetime_in_request = (now - datetime.datetime.utcfromtimestamp(0)).total_seconds() * 1000.0
+        resp = self.evervault.create_client_side_decrypt_token({"data": "ev:abc123"}, now)
+        assert request.called
+        assert resp == { "token": "token123", "expiry": 1234567890 }
+        assert request.last_request.json() == {"payload": {"data": "ev:abc123"}, "expiry": expected_datetime_in_request, "action": "decrypt:api" }
+
+    @requests_mock.Mocker()
+    def test_create_decrypt_token_without_payload_throws(self, mock_request):
+        self.assertRaises(
+            UndefinedDataError,
+            self.evervault.create_client_side_decrypt_token,
+            None,
+            None
+        )
 
     @requests_mock.Mocker()
     def test_decrypt_dict(self, mock_request):


### PR DESCRIPTION
# Why

Need to support the creation of decrypt tokens in the Python SDK

# How

- Add `create_client_side_decrypt_token()`

# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
