### PR TITLE
Pull arm linux compatible attestation doc version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ cryptography = "^41.0.0"
 certifi = "*"
 pycryptodome = "^3.10.1"
 pyasn1 = "^0.4.8"
-evervault-attestation-bindings = "0.3.1"
+evervault-attestation-bindings = "0.3.3"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"


### PR DESCRIPTION
# Why
The wheel files for linux arm weren't published in earlier versions causing installation failures

# How
Pull in version with arm linux wheel files https://pypi.org/project/evervault-attestation-bindings/#files
