### PR TITLE
Deprecating intercept and ignore domains

### DIFF
--- a/.changeset/fresh-flies-drive.md
+++ b/.changeset/fresh-flies-drive.md
@@ -1,0 +1,5 @@
+---
+"evervault-python": major
+---
+
+Deprecating intercept and ignore domains

--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -44,8 +44,6 @@ def init(
     app_id,
     api_key,
     decryption_domains=[],
-    intercept=False,
-    ignore_domains=[],
     retry=False,
     curve=Curves.SECP256K1,
     debug_requests=False,
@@ -61,29 +59,17 @@ def init(
     _retry = retry
     _curve = curve
 
-    if intercept or len(ignore_domains) > 0 or len(decryption_domains) > 0:
-        warn(
-            """
-                The `intercept`, `ignore_domains` & `decryption_domains` config options in the Evervault SDK are deprecated and slated for removal.\n
-                You can now use the `enable_outbound_relay` method to enable Outbound Relay.\n
-                For more details please see https://docs.evervault.com/reference/python-sdk#evervaultenable_outbound_relay
-            """,
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
     if len(decryption_domains) > 0:
         __client().enable_outbound_relay(
             debug_requests, decryption_domains=decryption_domains
         )
-    elif intercept or len(ignore_domains) > 0:
-        __client().enable_outbound_relay(debug_requests, ignore_domains=ignore_domains)
-    elif not intercept and enable_outbound_relay:
+    elif enable_outbound_relay:
         __client().enable_outbound_relay(
             debug_requests,
-            ignore_domains=ignore_domains,
             enable_outbound_relay=enable_outbound_relay,
         )
+    else:
+        __client()
 
 
 def run(function_name, data, options={"async": False, "version": None}):

--- a/evervault/client.py
+++ b/evervault/client.py
@@ -98,7 +98,6 @@ class Client(object):
     def enable_outbound_relay(
         self,
         debug_requests,
-        ignore_domains=[],
         decryption_domains=[],
         enable_outbound_relay=False,
         client_session=None,
@@ -107,8 +106,6 @@ class Client(object):
             self.cert.setup_decryption_domains(decryption_domains, debug_requests)
         elif enable_outbound_relay:
             self.cert.set_relay_outbound_config(debug_requests)
-        else:
-            self.cert.setup_ignore_domains(ignore_domains, debug_requests)
         self.cert.setup()
         if client_session:
             self.cert.setup_aiohttp(client_session)

--- a/evervault/http/requestintercept.py
+++ b/evervault/http/requestintercept.py
@@ -77,22 +77,6 @@ class RequestIntercept(object):
             host, decryption_domains, always_ignore_domains
         )
 
-    def setup_ignore_domains(self, ignore_domains, debug_requests=False):
-        self.debug_requests = debug_requests
-        ignore_domains.extend(self.get_always_ignore_domains())
-
-        ignore_if_exact = []
-        ignore_if_endswith = ()
-        for domain in ignore_domains:
-            if domain.startswith("www."):
-                domain = domain[4:]
-            ignore_if_exact.append(domain)
-            ignore_if_endswith += ("." + domain, "@" + domain)
-
-        self.should_proxy_domain = lambda host: not (
-            host in ignore_if_exact or host.endswith(ignore_if_endswith)
-        )
-
     def set_relay_outbound_config(self, debug_requests=False):
         self.debug_requests = debug_requests
         RelayOutboundConfig.init(self.request, self.base_url, self.debug_requests)

--- a/tests/test_evervault.py
+++ b/tests/test_evervault.py
@@ -398,7 +398,7 @@ class TestEvervault(unittest.TestCase):
         mock_request.get("https://ca.url.com", {})
 
         # Test default values
-        self.evervault.init("testAppUuid", "testing", intercept=True)
+        self.evervault.init("testAppUuid", "testing")
         assert self.evervault.ev_client.base_url == "https://api.evervault.com/"
         assert self.evervault.ev_client.base_run_url == "https://run.evervault.com/"
         assert self.evervault.ev_client.relay_url == "https://relay.evervault.com:443"
@@ -635,33 +635,6 @@ class TestEvervault(unittest.TestCase):
         assert request.last_request.headers["x-version-id"] == "2"
 
     @requests_mock.Mocker()
-    def test_run_with_intercept_domain(self, mock_request):
-        self.__mock_cert(mock_request)
-
-        evervault.init("testAppUuid", "testing", intercept=True)
-
-        request = mock_request.get("https://test2.com/hello")
-        requests.get("https://test2.com/hello")
-        assert request.last_request.headers["Proxy-Authorization"] == "testing"
-
-        self.__reinit_client()
-
-    @requests_mock.Mocker()
-    def test_run_with_intercept_cage_domain_ignored(self, mock_request):
-        self.__mock_cert(mock_request)
-
-        request = mock_request.get("https://run.evervault.com/hello")
-        evervault.init("testAppUuid", "testing", intercept=True)
-
-        requests.get("https://run.evervault.com/hello")
-
-        self.assertRaises(
-            KeyError, lambda: request.last_request.headers["Proxy-Authorization"]
-        )
-
-        self.__reinit_client()
-
-    @requests_mock.Mocker()
     def test_run_with_decryption_domain_constructor(self, mock_request):
         self.__mock_cert(mock_request)
 
@@ -730,19 +703,6 @@ class TestEvervault(unittest.TestCase):
         self.assertRaises(
             KeyError, lambda: request.last_request.headers["Proxy-Authorization"]
         )
-
-        self.__reinit_client()
-
-    @requests_mock.Mocker()
-    def test_run_with_intercept_with_allowed_domain(self, mock_request):
-        self.__mock_cert(mock_request)
-
-        request = mock_request.get("https://testing.com/hello")
-        evervault.init("testAppUuid", "testing", intercept=True)
-
-        requests.get("https://testing.com/hello")
-
-        assert request.last_request.headers["Proxy-Authorization"] == "testing"
 
         self.__reinit_client()
 


### PR DESCRIPTION
# Why

Removing deprecated logic ahead of upcoming major version bump

# How

Removed intercept and ignore domains
