### PR TITLE
Deprecating python 3 7

### DIFF
--- a/.changeset/small-games-rest.md
+++ b/.changeset/small-games-rest.md
@@ -1,0 +1,5 @@
+---
+"evervault-python": major
+---
+
+Deprecating support for Python 3.7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10.9, 3.11]
+        python-version: [3.8, 3.9, 3.10.9, 3.11]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,35 +7,6 @@ on:
       - "!master"
 
 jobs:
-  # Python 3.7 has compatibilities with openssl 3 so need to be run on an older ubuntu image with openssl 1.1.1
-  # https://github.com/dask/distributed/issues/5607#issuecomment-997090869
-  run-tests-3-dot-7:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Python 3.7
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-
-      - name: Check OpenSSL Version
-        run: openssl version
-
-      - name: Setup Poetry
-        uses: abatilo/actions-poetry@v2.1.2
-        with:
-          poetry-version: 1.4.2
-      - name: Install Dependencies
-        run: |
-          poetry install
-      - name: Run Lints
-        run: |
-          poetry run black -v --check .
-          poetry run flake8 -v --ignore=E501,W503,E722
-      - name: Run Tests
-        run: |
-          poetry run pytest -v 
-
   run-tests:
     runs-on: ubuntu-latest
     strategy:

--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -7,12 +7,7 @@ import sys
 from warnings import warn
 import warnings
 from evervault.http.attestationdoc import AttestationDoc
-
-try:
-    from importlib import metadata
-except ImportError:
-    # For Python 3.7
-    import importlib_metadata as metadata
+from importlib import metadata
 
 __version__ = metadata.version(__package__ or __name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ testpaths = ["tests"]
 
 [tool.black]
 line-length = 88
-target-version = ['py37', 'py38', 'py39']
+target-version = ['py38', 'py39', 'py310', 'py311']
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
# Why

Removing support for Python 3.7 ahead of upcoming major version bump

# How

Removed 3.7 specific logic
Removed 3.7 from tests
