### PR TITLE
Remove deprecated attestation

### DIFF
--- a/.changeset/new-wombats-compete.md
+++ b/.changeset/new-wombats-compete.md
@@ -1,0 +1,5 @@
+---
+"evervault-python": major
+---
+
+Remove deprecated Cage attestation session `cage_requests_session`, use `attestable_cage_session` instead

--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -1,7 +1,7 @@
 """Package for the evervault SDK"""
 from .client import Client
 from .errors.evervault_errors import EvervaultError
-from .cages_v2 import CageRequestsSessionBeta, CageRequestsSession
+from .cages_v2 import CageRequestsSession
 import os
 import sys
 from warnings import warn
@@ -23,7 +23,6 @@ BASE_URL_DEFAULT = "https://api.evervault.com/"
 RELAY_URL_DEFAULT = "https://relay.evervault.com:443"
 CA_HOST_DEFAULT = "https://ca.evervault.com"
 CAGES_CA_HOST_DEFAULT = "https://cages-ca.evervault.com"
-CAGES_BETA_HOST_DEFAULT = "cages.evervault.com"
 CAGES_GA_HOST_DEFAULT = "cage.evervault.com"
 MAX_FILE_SIZE_IN_MB_DEFAULT = 25
 DEFAULT_PCR_PROVIDER_POLL_INTERVAL = 300
@@ -82,18 +81,6 @@ def create_client_side_decrypt_token(payload, expiry=None):
 
 def encrypt(data):
     return __client().encrypt(data)
-
-
-def cage_requests_session(cage_attestation_data={}):
-    warnings.warn(
-        "cage_requests_session() is deprecated and will be removed in future versions. Use cage_attestable_session() instead.",
-        DeprecationWarning,
-    )
-    return CageRequestsSessionBeta(
-        cage_attestation_data,
-        os.environ.get("EV_CAGES_CA_HOST", CAGES_CA_HOST_DEFAULT),
-        os.environ.get("EV_CAGES_HOST", CAGES_BETA_HOST_DEFAULT),
-    )
 
 
 def attestable_cage_session(cage_attestation_data={}):

--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -21,8 +21,7 @@ _curve = None
 BASE_URL_DEFAULT = "https://api.evervault.com/"
 RELAY_URL_DEFAULT = "https://relay.evervault.com:443"
 CA_HOST_DEFAULT = "https://ca.evervault.com"
-CAGES_CA_HOST_DEFAULT = "https://cages-ca.evervault.com"
-CAGES_GA_HOST_DEFAULT = "cage.evervault.com"
+CAGES_HOST_DEFAULT = "cage.evervault.com"
 MAX_FILE_SIZE_IN_MB_DEFAULT = 25
 DEFAULT_PCR_PROVIDER_POLL_INTERVAL = 300
 
@@ -83,7 +82,7 @@ def encrypt(data):
 
 
 def attestable_cage_session(cage_attestation_data={}):
-    cage_host = os.environ.get("EV_CAGES_HOST_GA", CAGES_GA_HOST_DEFAULT)
+    cage_host = os.environ.get("EV_CAGES_HOST", CAGES_HOST_DEFAULT)
     cache = AttestationDoc(_app_uuid, cage_attestation_data.keys(), cage_host)
     pcr_manager = CagePcrManager(
         cage_attestation_data,

--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -5,7 +5,6 @@ from .cages_v2 import CageRequestsSession
 import os
 import sys
 from warnings import warn
-import warnings
 from evervault.http.attestationdoc import AttestationDoc
 from evervault.http.cagePcrManager import CagePcrManager
 from importlib import metadata

--- a/evervault/cages_v2.py
+++ b/evervault/cages_v2.py
@@ -2,9 +2,7 @@ import requests
 import urllib3
 import evervault_attestation_bindings
 from types import MethodType
-from evervault.errors.evervault_errors import EvervaultError
 from evervault.http.cagePcrManager import CagePcrManager
-import tempfile
 import base64
 
 
@@ -83,6 +81,7 @@ class CageHTTPAdapter(requests.adapters.HTTPAdapter):
 
         conn._validate_conn = MethodType(_validate_conn_override, conn)
         return conn
+
 
 class CageRequestsSession(requests.Session):
     def __init__(self, cage_pcr_manager, cages_host, cache):

--- a/evervault/cages_v2.py
+++ b/evervault/cages_v2.py
@@ -25,56 +25,6 @@ class CageVerificationException(Exception):
         super().__init__(message)
 
 
-# DEPRECATED: TO BE REMOVED IN NEXT MAJOR RELEASE
-class CageHTTPAdapterBeta(requests.adapters.HTTPAdapter):
-    def __init__(self, cage_attestation_data, cages_host):
-        self.attestation_data = cage_attestation_data
-        self.cages_host = cages_host
-        super().__init__()
-
-    def get_connection(self, url, proxies=None):
-        conn = super().get_connection(url, proxies)
-        if self.cages_host in url:
-            cage_name = get_cage_name_from_cage(url)
-            # we patch the urllib3.connectionpool.HTTPSConnectionPool object to perform extra validation on its connection before transmitting any data
-            conn = self.add_attestation_check_to_conn_validation(conn, cage_name)
-        return conn
-
-    def add_attestation_check_to_conn_validation(self, conn, cage_name):
-        expected_pcrs = []
-        if cage_name in self.attestation_data:
-            given_pcrs = self.attestation_data[cage_name]
-            # if the user only supplied a single set of PCRs, convert it to a list
-            if not isinstance(given_pcrs, list):
-                given_pcrs = [given_pcrs]
-
-            for pcrs in given_pcrs:
-                expected_pcrs.append(
-                    evervault_attestation_bindings.PCRs(
-                        pcrs.get("pcr_0"),
-                        pcrs.get("pcr_1"),
-                        pcrs.get("pcr_2"),
-                        pcrs.get("pcr_8"),
-                    )
-                )
-
-        original_validate_conn = (
-            urllib3.connectionpool.HTTPSConnectionPool._validate_conn
-        )
-
-        def _validate_conn_override(self, conn):
-            conn.connect()
-            cert = conn.sock.getpeercert(binary_form=True)
-            try:
-                evervault_attestation_bindings.attest_connection(cert, expected_pcrs)
-            except Exception as err:
-                raise CageVerificationException(err)
-            return original_validate_conn(self, conn)
-
-        conn._validate_conn = MethodType(_validate_conn_override, conn)
-        return conn
-
-
 class CageHTTPAdapter(requests.adapters.HTTPAdapter):
     def __init__(self, cage_pcr_manager: CagePcrManager, cages_host: str, cache):
         self.cage_pcr_manager = cage_pcr_manager
@@ -133,45 +83,6 @@ class CageHTTPAdapter(requests.adapters.HTTPAdapter):
 
         conn._validate_conn = MethodType(_validate_conn_override, conn)
         return conn
-
-
-# DEPRECATED: TO BE REMOVED IN NEXT MAJOR RELEASE
-class CageRequestsSessionBeta(requests.Session):
-    def __init__(self, cage_attestation_data, cage_ca_host, cages_host):
-        super().__init__()
-        self.mount("https://", CageHTTPAdapterBeta(cage_attestation_data, cages_host))
-        self.ca_host = cage_ca_host
-
-        ca_content = None
-        i = 0
-        while ca_content is None and i < 2:
-            i += 1
-            try:
-                ca_content = requests.get(self.ca_host).content
-            except:  # noqa: E722
-                pass
-
-        if ca_content is None:
-            raise EvervaultError(
-                f"Unable to install the Evervault Cages CA cert from {self.ca_host}. "
-            )
-
-        # todo add expiry
-        # self.__set_cert_expire_date(ca_content)
-
-        try:
-            with tempfile.NamedTemporaryFile(delete=False) as cert_file:
-                cert_file.write(ca_content)
-                self.cert_path = cert_file.name
-        except:
-            raise EvervaultError(
-                f"Unable to install the Evervault Cages CA cert from {self.ca_host}. "
-                "Likely a permissions error when attempting to write to the /tmp/ directory."
-            )
-
-    def request(self, *args, headers={}, **kwargs):
-        return super().request(*args, headers=headers, **kwargs, verify=self.cert_path)
-
 
 class CageRequestsSession(requests.Session):
     def __init__(self, cage_pcr_manager, cages_host, cache):

--- a/tests/test_attestatable_session.py
+++ b/tests/test_attestatable_session.py
@@ -97,32 +97,3 @@ class CageAttestationTest(unittest.TestCase):
             attested_session.get(
                 f"https://{self.cage_name}.{self.app_uuid}.cage.evervault.com/echo"
             )
-
-    def test_valid_pcrs_beta(self):
-        attested_session = self.evervault.cage_requests_session(
-            {
-                self.cage_name: {
-                    "pcr_8": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-                }
-            }
-        )
-        response = attested_session.get(
-            f"https://{self.cage_name}.{self.app_uuid}.cages.evervault.com/echo"
-        )
-        assert response.status_code == 401
-
-    def test_invalid_pcrs_beta(self):
-        with pytest.raises(
-            CageVerificationException,
-            match="The PCRs found were different to the expected values",
-        ):
-            attested_session = self.evervault.cage_requests_session(
-                {
-                    self.cage_name: {
-                        "pcr_8": "invalid000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-                    }
-                }
-            )
-            attested_session.get(
-                f"https://{self.cage_name}.{self.app_uuid}.cages.evervault.com/echo"
-            )


### PR DESCRIPTION
# Why

We deprecated the old attestation session, now we can remove it because we're doing a major release

# How

Remove
