### PR TITLE
[SPE-1025] Add enclave function to python SDK

### DIFF
--- a/.changeset/happy-trains-exercise.md
+++ b/.changeset/happy-trains-exercise.md
@@ -1,0 +1,5 @@
+---
+"evervault-python": minor
+---
+
+Added `attestable_enclave_session()` function to create an attestable request session with an Evervault Enclave. The `attestable_cage_session()` has been marked as deprecated as it will be removed in future versions of the SDK.

--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -89,10 +89,9 @@ def attestable_cage_session(cage_attestation_data={}):
         "attestable_cage_session() is deprecated and will be removed from v5.0.0 onwards. Use attestable_enclave_session() instead. When updating, also make sure your enclave has been deployed with the latest runtime.",
         DeprecationWarning,
     )
-    cage_host = os.environ.get("EV_CAGES_HOST", CAGES_HOST_DEFAULT)
-    enclave_host = os.environ.get("EV_ENCLAVE_HOST", ENCLAVE_HOST_DEFAULT)
+    host = os.environ.get("EV_CAGES_HOST", CAGES_HOST_DEFAULT)
     cache = AttestationDoc(
-        _app_uuid, cage_attestation_data.keys(), cage_host, enclave_host
+        _app_uuid, cage_attestation_data.keys(), host
     )
     pcr_manager = PcrManager(
         cage_attestation_data,
@@ -100,14 +99,13 @@ def attestable_cage_session(cage_attestation_data={}):
             "EV_PCR_PROVIDER_POLL_INTERVAL", DEFAULT_PCR_PROVIDER_POLL_INTERVAL
         ),
     )
-    return CageRequestsSession(pcr_manager, cage_host, cache)
+    return CageRequestsSession(pcr_manager, host, cache)
 
 
 def attestable_enclave_session(enclave_attestation_data={}):
-    cage_host = os.environ.get("EV_CAGES_HOST", CAGES_HOST_DEFAULT)
-    enclave_host = os.environ.get("EV_ENCLAVE_HOST", ENCLAVE_HOST_DEFAULT)
+    host = os.environ.get("EV_ENCLAVE_HOST", ENCLAVE_HOST_DEFAULT)
     cache = AttestationDoc(
-        _app_uuid, enclave_attestation_data.keys(), cage_host, enclave_host
+        _app_uuid, enclave_attestation_data.keys(), host
     )
     pcr_manager = PcrManager(
         enclave_attestation_data,
@@ -115,7 +113,7 @@ def attestable_enclave_session(enclave_attestation_data={}):
             "EV_PCR_PROVIDER_POLL_INTERVAL", DEFAULT_PCR_PROVIDER_POLL_INTERVAL
         ),
     )
-    return EnclaveRequestsSession(pcr_manager, enclave_host, cache)
+    return EnclaveRequestsSession(pcr_manager, host, cache)
 
 
 def create_run_token(function_name, data={}):

--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -90,8 +90,10 @@ def attestable_cage_session(cage_attestation_data={}):
         DeprecationWarning,
     )
     cage_host = os.environ.get("EV_CAGES_HOST", CAGES_HOST_DEFAULT)
-    enclave_host = os.environ.get("EV_ENCLAVE_HOST", ENCLAVE_HOST_DEFAULT);
-    cache = AttestationDoc(_app_uuid, cage_attestation_data.keys(), cage_host, enclave_host)
+    enclave_host = os.environ.get("EV_ENCLAVE_HOST", ENCLAVE_HOST_DEFAULT)
+    cache = AttestationDoc(
+        _app_uuid, cage_attestation_data.keys(), cage_host, enclave_host
+    )
     pcr_manager = PcrManager(
         cage_attestation_data,
         os.environ.get(
@@ -100,10 +102,13 @@ def attestable_cage_session(cage_attestation_data={}):
     )
     return CageRequestsSession(pcr_manager, cage_host, cache)
 
+
 def attestable_enclave_session(enclave_attestation_data={}):
     cage_host = os.environ.get("EV_CAGES_HOST", CAGES_HOST_DEFAULT)
-    enclave_host = os.environ.get("EV_ENCLAVE_HOST", ENCLAVE_HOST_DEFAULT);
-    cache = AttestationDoc(_app_uuid, enclave_attestation_data.keys(), cage_host, enclave_host)
+    enclave_host = os.environ.get("EV_ENCLAVE_HOST", ENCLAVE_HOST_DEFAULT)
+    cache = AttestationDoc(
+        _app_uuid, enclave_attestation_data.keys(), cage_host, enclave_host
+    )
     pcr_manager = PcrManager(
         enclave_attestation_data,
         os.environ.get(

--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -6,6 +6,7 @@ from .cages_v2 import CageRequestsSession
 import os
 import sys
 from warnings import warn
+import warnings
 from evervault.http.attestationdoc import AttestationDoc
 from evervault.http.pcrManager import PcrManager
 from importlib import metadata
@@ -84,6 +85,10 @@ def encrypt(data, role=None):
 
 
 def attestable_cage_session(cage_attestation_data={}):
+    warnings.warn(
+        "attestable_cage_session() is deprecated and will be removed from v5.0.0 onwards. Use attestable_enclave_session() instead. When updating, also make sure your enclave has been deployed with the latest runtime.",
+        DeprecationWarning,
+    )
     cage_host = os.environ.get("EV_CAGES_HOST", CAGES_HOST_DEFAULT)
     enclave_host = os.environ.get("EV_ENCLAVE_HOST", ENCLAVE_HOST_DEFAULT);
     cache = AttestationDoc(_app_uuid, cage_attestation_data.keys(), cage_host, enclave_host)
@@ -96,8 +101,9 @@ def attestable_cage_session(cage_attestation_data={}):
     return CageRequestsSession(pcr_manager, cage_host, cache)
 
 def attestable_enclave_session(enclave_attestation_data={}):
+    cage_host = os.environ.get("EV_CAGES_HOST", CAGES_HOST_DEFAULT)
     enclave_host = os.environ.get("EV_ENCLAVE_HOST", ENCLAVE_HOST_DEFAULT);
-    cache = AttestationDoc(_app_uuid, enclave_attestation_data.keys(), enclave_host)
+    cache = AttestationDoc(_app_uuid, enclave_attestation_data.keys(), cage_host, enclave_host)
     pcr_manager = PcrManager(
         enclave_attestation_data,
         os.environ.get(

--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -1,4 +1,5 @@
 """Package for the evervault SDK"""
+from evervault.enclaves import EnclaveRequestsSession
 from .client import Client
 from .errors.evervault_errors import EvervaultError
 from .cages_v2 import CageRequestsSession
@@ -6,7 +7,7 @@ import os
 import sys
 from warnings import warn
 from evervault.http.attestationdoc import AttestationDoc
-from evervault.http.cagePcrManager import CagePcrManager
+from evervault.http.pcrManager import PcrManager
 from importlib import metadata
 
 __version__ = metadata.version(__package__ or __name__)
@@ -22,6 +23,7 @@ BASE_URL_DEFAULT = "https://api.evervault.com/"
 RELAY_URL_DEFAULT = "https://relay.evervault.com:443"
 CA_HOST_DEFAULT = "https://ca.evervault.com"
 CAGES_HOST_DEFAULT = "cage.evervault.com"
+ENCLAVE_HOST_DEFAULT = "enclave.evervault.com"
 MAX_FILE_SIZE_IN_MB_DEFAULT = 25
 DEFAULT_PCR_PROVIDER_POLL_INTERVAL = 300
 
@@ -83,14 +85,26 @@ def encrypt(data, role=None):
 
 def attestable_cage_session(cage_attestation_data={}):
     cage_host = os.environ.get("EV_CAGES_HOST", CAGES_HOST_DEFAULT)
-    cache = AttestationDoc(_app_uuid, cage_attestation_data.keys(), cage_host)
-    pcr_manager = CagePcrManager(
+    enclave_host = os.environ.get("EV_ENCLAVE_HOST", ENCLAVE_HOST_DEFAULT);
+    cache = AttestationDoc(_app_uuid, cage_attestation_data.keys(), cage_host, enclave_host)
+    pcr_manager = PcrManager(
         cage_attestation_data,
         os.environ.get(
             "EV_PCR_PROVIDER_POLL_INTERVAL", DEFAULT_PCR_PROVIDER_POLL_INTERVAL
         ),
     )
     return CageRequestsSession(pcr_manager, cage_host, cache)
+
+def attestable_enclave_session(enclave_attestation_data={}):
+    enclave_host = os.environ.get("EV_ENCLAVE_HOST", ENCLAVE_HOST_DEFAULT);
+    cache = AttestationDoc(_app_uuid, enclave_attestation_data.keys(), enclave_host)
+    pcr_manager = PcrManager(
+        enclave_attestation_data,
+        os.environ.get(
+            "EV_PCR_PROVIDER_POLL_INTERVAL", DEFAULT_PCR_PROVIDER_POLL_INTERVAL
+        ),
+    )
+    return EnclaveRequestsSession(pcr_manager, enclave_host, cache)
 
 
 def create_run_token(function_name, data={}):

--- a/evervault/__init__.py
+++ b/evervault/__init__.py
@@ -90,9 +90,7 @@ def attestable_cage_session(cage_attestation_data={}):
         DeprecationWarning,
     )
     host = os.environ.get("EV_CAGES_HOST", CAGES_HOST_DEFAULT)
-    cache = AttestationDoc(
-        _app_uuid, cage_attestation_data.keys(), host
-    )
+    cache = AttestationDoc(_app_uuid, cage_attestation_data.keys(), host)
     pcr_manager = PcrManager(
         cage_attestation_data,
         os.environ.get(
@@ -104,9 +102,7 @@ def attestable_cage_session(cage_attestation_data={}):
 
 def attestable_enclave_session(enclave_attestation_data={}):
     host = os.environ.get("EV_ENCLAVE_HOST", ENCLAVE_HOST_DEFAULT)
-    cache = AttestationDoc(
-        _app_uuid, enclave_attestation_data.keys(), host
-    )
+    cache = AttestationDoc(_app_uuid, enclave_attestation_data.keys(), host)
     pcr_manager = PcrManager(
         enclave_attestation_data,
         os.environ.get(

--- a/evervault/enclaves.py
+++ b/evervault/enclaves.py
@@ -16,7 +16,9 @@ def get_enclave_name_from_enclave_url(enclave_url):
 
 class EnclaveVerificationException(Exception):
     def __init__(self, err):
-        message = f"An error occurred when attesting the connection to your Enclave: {err}"
+        message = (
+            f"An error occurred when attesting the connection to your Enclave: {err}"
+        )
         super().__init__(message)
 
 

--- a/evervault/enclaves.py
+++ b/evervault/enclaves.py
@@ -6,42 +6,39 @@ from evervault.http.pcrManager import PcrManager
 import base64
 
 
-def get_cage_name_from_cage(cage_url):
-    requested_cage_hostname = cage_url
-    if "https://" in requested_cage_hostname:
-        requested_cage_hostname = cage_url[len("https://") :]  # noqa: E203
-    requested_cage_hostname_tokens = requested_cage_hostname.split(".")
-    if requested_cage_hostname_tokens[1] == "attest":
-        return requested_cage_hostname_tokens[2]
-    else:
-        return requested_cage_hostname_tokens[0]
+def get_enclave_name_from_enclave_url(enclave_url):
+    requested_enclave_hostname = enclave_url
+    if "https://" in requested_enclave_hostname:
+        requested_enclave_hostname = enclave_url[len("https://") :]  # noqa: E203
+    requested_enclave_hostname_tokens = requested_enclave_hostname.split(".")
+    return requested_enclave_hostname_tokens[0]
 
 
-class CageVerificationException(Exception):
+class EnclaveVerificationException(Exception):
     def __init__(self, err):
-        message = f"An error occurred when attesting the connection to your Cage: {err}"
+        message = f"An error occurred when attesting the connection to your Enclave: {err}"
         super().__init__(message)
 
 
-class CageHTTPAdapter(requests.adapters.HTTPAdapter):
-    def __init__(self, pcr_manager: PcrManager, cages_host: str, cache):
+class EnclaveHTTPAdapter(requests.adapters.HTTPAdapter):
+    def __init__(self, pcr_manager: PcrManager, enclave_host: str, cache):
         self.pcr_manager = pcr_manager
-        self.cages_host = cages_host
+        self.enclave_host = enclave_host
         self.cache = cache
         super().__init__()
 
     def get_connection(self, url, proxies=None):
         conn = super().get_connection(url, proxies)
-        if self.cages_host in url:
-            cage_name = get_cage_name_from_cage(url)
+        if self.enclave_host in url:
+            enclave_name = get_enclave_name_from_enclave_url(url)
             # we patch the urllib3.connectionpool.HTTPSConnectionPool object to perform extra validation on its connection before transmitting any data
-            conn = self.add_attestation_check_to_conn_validation(conn, cage_name)
+            conn = self.add_attestation_check_to_conn_validation(conn, enclave_name)
         return conn
 
-    def add_attestation_check_to_conn_validation(self, conn, cage_name):
+    def add_attestation_check_to_conn_validation(self, conn, enclave_name):
         cache = self.cache
 
-        pcrs_from_manager = self.pcr_manager.get(cage_name)
+        pcrs_from_manager = self.pcr_manager.get(enclave_name)
         expected_pcrs = []
 
         if pcrs_from_manager is not None:
@@ -59,8 +56,8 @@ class CageHTTPAdapter(requests.adapters.HTTPAdapter):
             urllib3.connectionpool.HTTPSConnectionPool._validate_conn
         )
 
-        def attest_cage(cage_name, cache, cert, expected_pcrs):
-            attestation_doc = cache.get(cage_name)
+        def attest_enclave(enclave_name, cache, cert, expected_pcrs):
+            attestation_doc = cache.get(enclave_name)
             attestation_doc_bytes = base64.b64decode(attestation_doc)
             evervault_attestation_bindings.attest_cage(
                 cert, expected_pcrs, attestation_doc_bytes
@@ -70,23 +67,23 @@ class CageHTTPAdapter(requests.adapters.HTTPAdapter):
             conn.connect()
             cert = conn.sock.getpeercert(binary_form=True)
             try:
-                attest_cage(cage_name, cache, cert, expected_pcrs)
+                attest_enclave(enclave_name, cache, cert, expected_pcrs)
             except Exception:
                 try:
-                    cache.load_doc(cage_name)
-                    attest_cage(cage_name, cache, cert, expected_pcrs)
+                    cache.load_doc(enclave_name)
+                    attest_enclave(enclave_name, cache, cert, expected_pcrs)
                 except Exception as err:
-                    raise CageVerificationException(err)
+                    raise EnclaveVerificationException(err)
             return original_validate_conn(self, conn)
 
         conn._validate_conn = MethodType(_validate_conn_override, conn)
         return conn
 
 
-class CageRequestsSession(requests.Session):
-    def __init__(self, pcr_manager, cages_host, cache):
+class EnclaveRequestsSession(requests.Session):
+    def __init__(self, pcr_manager, enclave_host, cache):
         super().__init__()
-        self.mount("https://", CageHTTPAdapter(pcr_manager, cages_host, cache))
+        self.mount("https://", EnclaveHTTPAdapter(pcr_manager, enclave_host, cache))
 
     def request(self, *args, headers={}, **kwargs):
         return super().request(*args, headers=headers, **kwargs)

--- a/evervault/http/attestationdoc.py
+++ b/evervault/http/attestationdoc.py
@@ -9,9 +9,8 @@ logger = logging.getLogger(__name__)
 
 
 class AttestationDoc:
-    def __init__(self, app_uuid, names, cage_host, enclave_host, poll_interval=300):
-        self.cage_host = cage_host
-        self.enclave_host = enclave_host
+    def __init__(self, app_uuid, names, host, poll_interval=300):
+        self.host = host
         self.app_uuid = app_uuid.replace("_", "-")
         self.names = names
         self.poll_interval = poll_interval
@@ -61,21 +60,13 @@ class AttestationDoc:
     def __get_url(self, name, host):
         return f"https://{name}.{self.app_uuid}.{host}/.well-known/attestation"
 
-    # While supporting both cage and enclave, we should attempt to get the attestation docs
-    # from both the cage and enclave hosts.
     def __get_attestation_doc(self, name):
         try:
-            cage_url = self.__get_url(name, self.cage_host)
-            res = requests.get(cage_url)
+            url = self.__get_url(name, self.host)
+            res = requests.get(url)
             body = res.json()
             return (name, body["attestation_doc"])
-        except Exception as cage_err:
-            try:
-                enclave_url = self.__get_url(name, self.enclave_host)
-                res = requests.get(enclave_url)
-                body = res.json()
-                return (name, body["attestation_doc"])
-            except Exception as enclave_err:
-                warnings.warn(
-                    f"Could not retrieve attestation doc from {cage_url}: {cage_err}. Or {enclave_url}: {enclave_err}"
-                )
+        except Exception as err:
+            warnings.warn(
+                f"Could not retrieve attestation doc from {url}: {err}."
+            )

--- a/evervault/http/attestationdoc.py
+++ b/evervault/http/attestationdoc.py
@@ -9,8 +9,9 @@ logger = logging.getLogger(__name__)
 
 
 class AttestationDoc:
-    def __init__(self, app_uuid, names, host, poll_interval=300):
-        self.host = host
+    def __init__(self, app_uuid, names, cage_host, enclave_host, poll_interval=300):
+        self.cage_host = cage_host
+        self.enclave_host = enclave_host
         self.app_uuid = app_uuid.replace("_", "-")
         self.names = names
         self.poll_interval = poll_interval
@@ -57,11 +58,22 @@ class AttestationDoc:
         docs = dict(list(map(self.__get_attestation_doc, self.names)))
         self.update_cache(docs)
 
+    def __get_url(self, name, host):
+        return f"https://{name}.{self.app_uuid}.{host}/.well-known/attestation"
+
+    # While supporting both cage and enclave, we should attempt to get the attestation docs
+    # from both the cage and enclave hosts.
     def __get_attestation_doc(self, name):
         try:
-            url = f"https://{name}.{self.app_uuid}.{self.host}/.well-known/attestation"
-            res = requests.get(url)
+            cage_url = self.__get_url(name, self.cage_host)
+            res = requests.get(cage_url)
             body = res.json()
             return (name, body["attestation_doc"])
-        except Exception as e:
-            warnings.warn(f"Could not retrieve attestation doc from {url} {e}")
+        except Exception as cage_err:
+            try:
+                enclave_url = self.__get_url(name, self.enclave_host)
+                res = requests.get(enclave_url)
+                body = res.json()
+                return (name, body["attestation_doc"])
+            except Exception as enclave_err:
+                warnings.warn(f"Could not retrieve attestation doc from {cage_url}: {cage_err}. Or {enclave_url}: {enclave_err}")

--- a/evervault/http/attestationdoc.py
+++ b/evervault/http/attestationdoc.py
@@ -67,6 +67,4 @@ class AttestationDoc:
             body = res.json()
             return (name, body["attestation_doc"])
         except Exception as err:
-            warnings.warn(
-                f"Could not retrieve attestation doc from {url}: {err}."
-            )
+            warnings.warn(f"Could not retrieve attestation doc from {url}: {err}.")

--- a/evervault/http/attestationdoc.py
+++ b/evervault/http/attestationdoc.py
@@ -9,10 +9,10 @@ logger = logging.getLogger(__name__)
 
 
 class AttestationDoc:
-    def __init__(self, app_uuid, cage_names, cage_host, poll_interval=300):
-        self.cage_host = cage_host
+    def __init__(self, app_uuid, names, host, poll_interval=300):
+        self.host = host
         self.app_uuid = app_uuid.replace("_", "-")
-        self.cage_names = cage_names
+        self.names = names
         self.poll_interval = poll_interval
         self.lock = threading.Lock()
         self.cache = {}
@@ -24,13 +24,13 @@ class AttestationDoc:
             self.__get_attestation_docs,
         )
 
-    def get(self, cage_name) -> str:
+    def get(self, name) -> str:
         with self.lock:
             try:
-                return self.cache[cage_name]
+                return self.cache[name]
             except KeyError:
-                (_, doc) = self.__get_attestation_doc(cage_name)
-                self.cache[cage_name] = doc
+                (_, doc) = self.__get_attestation_doc(name)
+                self.cache[name] = doc
                 return doc
 
     def get_poll_interval(self) -> list:
@@ -49,19 +49,19 @@ class AttestationDoc:
         with self.lock:
             self.cache = docs
 
-    def load_doc(self, cage_name):
-        self.__get_attestation_doc(cage_name)
+    def load_doc(self, name):
+        self.__get_attestation_doc(name)
 
     def __get_attestation_docs(self):
         logger.debug("EVERVAULT :: Retrieving attestation doc from Cage")
-        docs = dict(list(map(self.__get_attestation_doc, self.cage_names)))
+        docs = dict(list(map(self.__get_attestation_doc, self.names)))
         self.update_cache(docs)
 
-    def __get_attestation_doc(self, cage_name):
+    def __get_attestation_doc(self, name):
         try:
-            url = f"https://{cage_name}.{self.app_uuid}.{self.cage_host}/.well-known/attestation"
+            url = f"https://{name}.{self.app_uuid}.{self.host}/.well-known/attestation"
             res = requests.get(url)
             body = res.json()
-            return (cage_name, body["attestation_doc"])
+            return (name, body["attestation_doc"])
         except Exception as e:
             warnings.warn(f"Could not retrieve attestation doc from {url} {e}")

--- a/evervault/http/attestationdoc.py
+++ b/evervault/http/attestationdoc.py
@@ -76,4 +76,6 @@ class AttestationDoc:
                 body = res.json()
                 return (name, body["attestation_doc"])
             except Exception as enclave_err:
-                warnings.warn(f"Could not retrieve attestation doc from {cage_url}: {cage_err}. Or {enclave_url}: {enclave_err}")
+                warnings.warn(
+                    f"Could not retrieve attestation doc from {cage_url}: {cage_err}. Or {enclave_url}: {enclave_err}"
+                )

--- a/evervault/http/pcrManager.py
+++ b/evervault/http/pcrManager.py
@@ -8,7 +8,7 @@ import time
 logger = logging.getLogger(__name__)
 
 
-class CagePcrManager:
+class PcrManager:
     def __init__(self, attestation_data, poll_interval=300):
         self.attestation_data = attestation_data
         self.poll_interval = poll_interval
@@ -19,7 +19,7 @@ class CagePcrManager:
         self.__fetch_all_pcrs()
 
         logger.debug(
-            "EVERVAULT :: Cage PCR manager starting polling for PCRs every {self.poll_interval} seconds"
+            "EVERVAULT :: PCR manager starting polling for PCRs every {self.poll_interval} seconds"
         )
 
         self.repeated_timer = RepeatedTimer(
@@ -80,7 +80,7 @@ class CagePcrManager:
                 raise Exception("EVERVAULT :: Invalid PCR data. Cannot create provider")
 
     def __fetch_all_pcrs(self):
-        logger.debug("EVERVAULT :: Retrieving Cage PCRs from providers")
+        logger.debug("EVERVAULT :: Retrieving PCRs from providers")
         for cage_name, provider in self.store.items():
             pcrs = self.__fetch_pcrs(cage_name)
             self.store[cage_name]["pcrs"] = pcrs

--- a/evervault/http/pcrManager.py
+++ b/evervault/http/pcrManager.py
@@ -19,7 +19,7 @@ class PcrManager:
         self.__fetch_all_pcrs()
 
         logger.debug(
-            "EVERVAULT :: PCR manager starting polling for PCRs every {self.poll_interval} seconds"
+            "EVERVAULT :: PCR manager starting to poll for PCRs every {self.poll_interval} seconds"
         )
 
         self.repeated_timer = RepeatedTimer(

--- a/tests/test_enclave_attestatable_session.py
+++ b/tests/test_enclave_attestatable_session.py
@@ -1,0 +1,99 @@
+import unittest
+
+import requests
+import pytest
+import importlib
+import evervault
+
+from evervault.enclaves import EnclaveVerificationException
+
+
+class EnclaveAttestationTest(unittest.TestCase):
+    def setUp(self):
+        importlib.reload(evervault)
+        self.evervault = evervault
+        self.app_uuid = "app-f5f084041a7e"
+        self.enclave_name = "synthetic-cage"
+        self.evervault.init(self.app_uuid, "testing", curve="SECP256K1")
+
+    def test_valid_pcrs(self):
+        attested_session = self.evervault.attestable_enclave_session(
+            {
+                self.enclave_name: {
+                    "pcr_8": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+                }
+            }
+        )
+        response = attested_session.get(
+            f"https://{self.enclave_name}.{self.app_uuid}.enclave.evervault.com/echo"
+        )
+        assert response.status_code == 401
+
+    def test_valid_pcrs_from_array(self):
+
+        attested_session = self.evervault.attestable_enclave_session(
+            {
+                self.enclave_name: [
+                    {
+                        "pcr_8": "invalid00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+                    },
+                    {
+                        "pcr_8": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+                    },
+                ]
+            }
+        )
+        response = attested_session.get(
+            f"https://{self.enclave_name}.{self.app_uuid}.enclave.evervault.com/echo"
+        )
+        assert response.status_code == 401
+
+    def test_valid_pcrs_from_provider(self):
+        def provider():
+            pcrs = requests.get(
+                "https://gist.githubusercontent.com/donaltuohy/5dbc1c175bcd0f0a9a621184cf3c78dc/raw/df25a123dea6424fb630ea80f241c676931728da/pcrs.json"
+            ).json()
+            return pcrs
+
+        attested_session = self.evervault.attestable_enclave_session(
+            {self.enclave_name: provider}
+        )
+        response = attested_session.get(
+            f"https://{self.enclave_name}.{self.app_uuid}.enclave.evervault.com/echo"
+        )
+        assert response.status_code == 401
+
+    def test_invalid_pcrs_from_provider(self):
+        def provider():
+            pcrs = requests.get(
+                "https://gist.githubusercontent.com/hanneary/d076f6702c1694d29c117a1e00f1957e/raw/2c4999694e302cedb6283ba531dcdab45d556bcc/invalidpcr.json"
+            ).json()
+            return pcrs
+
+        with pytest.raises(
+            EnclaveVerificationException,
+            match="The PCRs found were different to the expected values",
+        ):
+            attested_session = self.evervault.attestable_enclave_session(
+                {self.enclave_name: provider}
+            )
+
+            attested_session.get(
+                f"https://{self.enclave_name}.{self.app_uuid}.enclave.evervault.com/echo"
+            )
+
+    def test_invalid_pcrs(self):
+        with pytest.raises(
+            EnclaveVerificationException,
+            match="The PCRs found were different to the expected values",
+        ):
+            attested_session = self.evervault.attestable_enclave_session(
+                {
+                    self.enclave_name: {
+                        "pcr_8": "invalid000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+                    }
+                }
+            )
+            attested_session.get(
+                f"https://{self.enclave_name}.{self.app_uuid}.enclave.evervault.com/echo"
+            )

--- a/tests/test_pcrs_manager.py
+++ b/tests/test_pcrs_manager.py
@@ -1,8 +1,8 @@
 import unittest
-from evervault.http.cagePcrManager import CagePcrManager
+from evervault.http.pcrManager import PcrManager
 
 
-class TestCagePcrManager(unittest.TestCase):
+class TestPcrManager(unittest.TestCase):
     def setUp(self):
         self.app_uuid = "app-123"
         self.cage_1 = "cage_1"
@@ -28,7 +28,7 @@ class TestCagePcrManager(unittest.TestCase):
 
         attestation_data = {self.cage_1: test_provider1, self.cage_2: test_provider2}
 
-        manager = CagePcrManager(attestation_data)
+        manager = PcrManager(attestation_data)
 
         assert manager.get(self.cage_1) == test_pcrs1
         assert manager.get(self.cage_2) == test_pcrs2
@@ -47,7 +47,7 @@ class TestCagePcrManager(unittest.TestCase):
         ]
         attestation_data = {self.cage_1: test_pcrs_object, self.cage_2: test_pcrs_array}
 
-        manager = CagePcrManager(attestation_data)
+        manager = PcrManager(attestation_data)
 
         assert manager.get(self.cage_1) == [test_pcrs_object]
         assert manager.get(self.cage_2) == test_pcrs_array
@@ -64,7 +64,7 @@ class TestCagePcrManager(unittest.TestCase):
 
         attestation_data = {self.cage_1: test_provider1}
 
-        manager = CagePcrManager(attestation_data)
+        manager = PcrManager(attestation_data)
 
         # Remove pcrs for cage_1 so that we test the reload on a miss
         manager.remove_pcrs_for_cage(self.cage_1)


### PR DESCRIPTION
# Why
New hostname

# How
Add new function attestable_enclave_session() which returns a http session to use for attesting requests to enclaves.
Mark the old attestatble_cage_session() as deprecated as it will be removed in future versions.
