### PR TITLE
fix: remove PAT token and use checkout v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
 
       - name: Get tags
         run: git fetch --tags origin
-  
+
       - name: Setup Python 3.9
         uses: actions/setup-python@v2
         with:
@@ -41,7 +38,7 @@ jobs:
       - name: Run Tests
         run: |
           poetry run pytest -v
-    
+
       - name: Create Release Pull Request
         id: changesets
         uses: changesets/action@v1
@@ -51,7 +48,7 @@ jobs:
           version: npm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-    
+
       - name: Create new release
         if: steps.changesets.outputs.hasChangesets == 'false'
         run: |


### PR DESCRIPTION
# Why
Should fix access denied when releasing the SDK

# How
- Not sure why we are using a PAT for checkout, removed to auto use actions token
- Bumped checkout version
