### PR TITLE
fix: remove all references to token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Get tags
         run: git fetch --tags origin
-  
+
       - name: Setup Python 3.9
         uses: actions/setup-python@v2
         with:
@@ -41,7 +41,7 @@ jobs:
       - name: Run Tests
         run: |
           poetry run pytest -v
-    
+
       - name: Create Release Pull Request
         id: changesets
         uses: changesets/action@v1
@@ -50,8 +50,8 @@ jobs:
           commit: 'Release new version'
           version: npm run version
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-    
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create new release
         if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
@@ -59,7 +59,7 @@ jobs:
           COMMIT_TAG=$(git tag --points-at HEAD)
           if [ -n "$COMMIT_TAG" ]; then
             echo "A tag is attached to HEAD. Creating a new release..."
-            echo "${{ secrets.GH_TOKEN }}" | gh auth login --with-token
+            echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
             CHANGELOG=$(awk '
               BEGIN { recording=0; }
               /^## / {


### PR DESCRIPTION
# Why
The PAT token remains in the workflow causes PR to fail to open

# How
Use ${{ secrets.GITHUB_TOKEN }} 
