### PR TITLE
Upgrade pyasn1 to patched version

### DIFF
--- a/.changeset/some-terms-draw.md
+++ b/.changeset/some-terms-draw.md
@@ -1,0 +1,5 @@
+---
+"evervault-python": patch
+---
+
+Bump pyasn1 to 0.6.4 to remove vulnerability in decoding

--- a/poetry.lock
+++ b/poetry.lock
@@ -308,7 +308,7 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["dev"]
-markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
+markers = "sys_platform == \"win32\" or platform_system == \"Windows\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -595,14 +595,14 @@ testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]
@@ -1037,4 +1037,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10.0"
-content-hash = "563ec625b01c323334e5f9fa31914565d6724ccbb17af96d39ef549e9d94adbe"
+content-hash = "6af6fc7fa23446ade8123c2df62ed80a468fac3ebd645c319d4fb023cbbde2e5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requests = "^2.32.4"
 cryptography = ">=46.0.6,<49"
 certifi = "*"
 pycryptodome = "^3.10.1"
-pyasn1 = "^0.6.3"
+pyasn1 = "^0.6.4"
 evervault-attestation-bindings = "0.5.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
# Why

pyasn1 has a vulnerability in decoding which is patched in 0.6.4, there is no impact to this SDK. This patch is primarily for good hygeine.

# How

Patch pyasn1 to 0.6.4
