### PR TITLE
Widen cryptography dependency version cosntraint

### DIFF
--- a/.changeset/salty-crews-cut.md
+++ b/.changeset/salty-crews-cut.md
@@ -1,0 +1,5 @@
+---
+"evervault-python": patch
+---
+
+Support consumption of the evervault python sdk with cryptography v49

--- a/poetry.lock
+++ b/poetry.lock
@@ -1037,4 +1037,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10.0"
-content-hash = "6af6fc7fa23446ade8123c2df62ed80a468fac3ebd645c319d4fb023cbbde2e5"
+content-hash = "7730578aedbd494bf3178942ce49f1540474fd3030d3e87600a6ea1ae314b3f6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/evervault/evervault-python"
 [tool.poetry.dependencies]
 python = "^3.10.0"
 requests = "^2.32.4"
-cryptography = ">=46.0.6,<49"
+cryptography = ">=46.0.6,<50"
 certifi = "*"
 pycryptodome = "^3.10.1"
 pyasn1 = "^0.6.4"


### PR DESCRIPTION
# Why

Our SDK is fully compatible with cryptography v49, so we can lift the version cap

# How

Audit compatibility, verifying that none of the breaking changes in the cryptography module impact our consumption in this project.
